### PR TITLE
fix(stat): show Mellanox mlx5 traffic; add IB perftest example

### DIFF
--- a/examples/ib/README.md
+++ b/examples/ib/README.md
@@ -39,7 +39,7 @@ follows the `<tool> [opts] [server_ip]` convention works.
 ## Examples
 
 ```bash
-# RDMA write bandwidth, 10s, 1 QP, mlx5_1
+# RDMA write bandwidth, 30s, 1 QP, mlx5_1
 ./examples/ib/ib.sh amd0 amd1
 
 # RDMA read bandwidth

--- a/examples/ib/README.md
+++ b/examples/ib/README.md
@@ -1,0 +1,79 @@
+# IB Perftest
+
+[perftest](https://github.com/linux-rdma/perftest) is the standard
+suite of micro-benchmarks for RDMA verbs — `ib_write_bw`, `ib_read_bw`,
+`ib_send_bw`, `ib_write_lat`, and friends. Each test is a two-process
+program: one rank acts as a server, the other connects as a client.
+
+`examples/ib/ib.sh` is a thin wrapper that launches both ranks across
+two hosts with `mpirun`, so you can benchmark inter-node RDMA with a
+single command and observe the traffic in `rdmatop` from another shell.
+
+## Prerequisites
+
+- `perftest` and an MPI launcher installed on both hosts:
+  ```bash
+  sudo apt install -y perftest openmpi-bin
+  ```
+- Passwordless SSH from the launcher host to both hosts (mpirun shells
+  in to spawn each rank):
+  ```bash
+  ssh-keygen -t ed25519 -N "" -f ~/.ssh/id_ed25519
+  ssh-copy-id user@host1
+  ssh-copy-id user@host2
+  ```
+- An RDMA device that is ACTIVE on both ends (`rdma link`) and a netdev
+  with an IPv4 address reachable between the two hosts.
+
+## Usage
+
+```bash
+./examples/ib/ib.sh <host1> <host2> [perftest_binary]
+#   host1 -> rank 0 -> server
+#   host2 -> rank 1 -> client (dials host1)
+```
+
+`perftest_binary` defaults to `ib_write_bw`. Any perftest tool that
+follows the `<tool> [opts] [server_ip]` convention works.
+
+## Examples
+
+```bash
+# RDMA write bandwidth, 10s, 1 QP, mlx5_1
+./examples/ib/ib.sh amd0 amd1
+
+# RDMA read bandwidth
+./examples/ib/ib.sh amd0 amd1 ib_read_bw
+
+# Send latency
+./examples/ib/ib.sh amd0 amd1 ib_send_lat
+
+# Longer run with 4 queue pairs (closer to line rate)
+IB_DURATION=30 IB_QPS=4 ./examples/ib/ib.sh amd0 amd1
+
+# Sweep all message sizes
+IB_EXTRA="-a" ./examples/ib/ib.sh amd0 amd1
+
+# Use a different RDMA device + matching netdev
+IB_DEV=mlx5_0 IB_NETDEV=enp49s0f0np0 ./examples/ib/ib.sh amd0 amd1
+```
+
+## Environment Variables
+
+| Variable      | Default          | Purpose                                                |
+|---------------|------------------|--------------------------------------------------------|
+| `IB_DEV`      | `mlx5_1`         | RDMA device passed as `-d`                             |
+| `IB_NETDEV`   | `enp49s0f1np1`   | Netdev paired with `IB_DEV`; used to look up host1's IP |
+| `IB_DURATION` | `30`             | Seconds, passed as `-D`                                |
+| `IB_QPS`      | `1`              | Queue pairs, passed as `-q`                            |
+| `IB_EXTRA`    | (empty)          | Extra args appended verbatim to the perftest binary    |
+| `MPI_EXTRA`   | (empty)          | Extra args passed to `mpirun`                          |
+
+## Related Links
+
+- [perftest](https://github.com/linux-rdma/perftest)
+  — upstream RDMA verbs benchmarks
+- [Open MPI](https://www.open-mpi.org/)
+  — `mpirun` launcher
+- [rdma-core](https://github.com/linux-rdma/rdma-core)
+  — userspace RDMA libraries and drivers

--- a/examples/ib/ib.sh
+++ b/examples/ib/ib.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# ib.sh - launch a perftest benchmark between two hosts via mpirun.
+#
+# Usage:
+#   ./ib.sh <host1> <host2> [perftest_binary]
+#     host1 -> rank 0 -> perftest server
+#     host2 -> rank 1 -> perftest client (connects to host1)
+#     perftest_binary defaults to ib_write_bw
+#
+# Env overrides:
+#   IB_DEV       RDMA device                   (default: mlx5_1)
+#   IB_NETDEV    netdev paired with IB_DEV     (default: enp49s0f1np1)
+#                used to look up host1's IP so host2 can dial it
+#   IB_DURATION  perftest -D seconds           (default: 30)
+#   IB_QPS       perftest -q queue pairs       (default: 1)
+#   IB_EXTRA     extra args appended verbatim  (default: empty)
+#   MPI_EXTRA    extra args passed to mpirun   (default: empty)
+#
+# Examples:
+#   ./ib.sh amd0 amd1
+#   ./ib.sh amd0 amd1 ib_read_bw
+#   IB_DURATION=30 IB_QPS=4 ./ib.sh amd0 amd1 ib_write_bw
+#   IB_DEV=mlx5_0 IB_NETDEV=enp49s0f0np0 ./ib.sh amd0 amd1
+
+set -euo pipefail
+
+IB_DEV=${IB_DEV:-mlx5_1}
+IB_NETDEV=${IB_NETDEV:-enp49s0f1np1}
+IB_DURATION=${IB_DURATION:-30}
+IB_QPS=${IB_QPS:-1}
+IB_EXTRA=${IB_EXTRA:-}
+MPI_EXTRA=${MPI_EXTRA:-}
+
+# Worker mode: mpirun re-invokes this script on each host with a rank set.
+rank=${OMPI_COMM_WORLD_RANK:-${PMI_RANK:-${PMIX_RANK:-}}}
+if [[ -n "${rank}" ]]; then
+  test_bin=$1
+  peer_ip=$2
+  common=(-d "$IB_DEV" -F -D "$IB_DURATION" -q "$IB_QPS" $IB_EXTRA)
+  if [[ "$rank" == "0" ]]; then
+    echo "[$(hostname)] rank 0: $test_bin ${common[*]}  (server)"
+    exec "$test_bin" "${common[@]}"
+  else
+    # Tiny delay so the server's TCP listener is up before we dial.
+    sleep 1
+    echo "[$(hostname)] rank 1: $test_bin ${common[*]} $peer_ip  (client)"
+    exec "$test_bin" "${common[@]}" "$peer_ip"
+  fi
+fi
+
+# Launcher mode
+if [[ $# -lt 2 ]]; then
+  sed -n '2,25p' "$0"
+  exit 2
+fi
+
+host1=$1
+host2=$2
+test_bin=${3:-ib_write_bw}
+
+# Resolve host1's IP on the RDMA-adjacent netdev so host2 can connect to it.
+peer_ip=$(ssh -o BatchMode=yes "$host1" \
+  "ip -br -4 addr show $IB_NETDEV 2>/dev/null | awk '{print \$3}' | cut -d/ -f1")
+if [[ -z "$peer_ip" ]]; then
+  echo "ERROR: could not resolve IPv4 on $IB_NETDEV at $host1" >&2
+  echo "       set IB_NETDEV to a netdev that has an IP on both hosts." >&2
+  exit 1
+fi
+
+script=$(readlink -f "$0")
+echo "=== ib.sh ==="
+echo "  test     : $test_bin"
+echo "  hosts    : $host1 (server) -> $host2 (client)"
+echo "  device   : $IB_DEV  via netdev $IB_NETDEV"
+echo "  peer ip  : $peer_ip"
+echo "  duration : ${IB_DURATION}s   qps=${IB_QPS}"
+[[ -n "$IB_EXTRA"  ]] && echo "  extra    : $IB_EXTRA"
+[[ -n "$MPI_EXTRA" ]] && echo "  mpi extra: $MPI_EXTRA"
+echo
+
+exec mpirun --host "$host1,$host2" -np 2 \
+  --tag-output \
+  $MPI_EXTRA \
+  "$script" "$test_bin" "$peer_ip"

--- a/src/stat.rs
+++ b/src/stat.rs
@@ -83,7 +83,44 @@ fn parse_port_stat(nlmsg: &NlMsg) -> Option<PortStat> {
             _ => {}
         }
     }
-    (!stat.dev_name.is_empty()).then_some(stat)
+    if stat.dev_name.is_empty() {
+        return None;
+    }
+    fill_missing_from_sysfs(&mut stat);
+    Some(stat)
+}
+
+// Standard IB port counters in /sys/class/infiniband/<dev>/ports/<n>/counters/
+// are exposed by every RDMA provider. Mellanox doesn't publish tx_bytes/rx_bytes
+// as hw_counters (those are Broadcom-specific), so we synthesize them here
+// from the standard names. Data fields are in 4-byte words per IB spec.
+const SYSFS_FALLBACK: &[(&str, &str, u64)] = &[
+    ("tx_bytes", "port_xmit_data", 4),
+    ("rx_bytes", "port_rcv_data", 4),
+    ("tx_pkts", "port_xmit_packets", 1),
+    ("rx_pkts", "port_rcv_packets", 1),
+];
+
+fn fill_missing_from_sysfs(stat: &mut PortStat) {
+    for (synth_name, file, mult) in SYSFS_FALLBACK {
+        if stat.counters.iter().any(|c| c.name == *synth_name) {
+            continue;
+        }
+        let path = format!(
+            "/sys/class/infiniband/{}/ports/{}/counters/{}",
+            stat.dev_name, stat.port, file
+        );
+        let Ok(raw) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let Ok(v) = raw.trim().parse::<u64>() else {
+            continue;
+        };
+        stat.counters.push(HwCounter {
+            name: (*synth_name).to_string(),
+            value: v.saturating_mul(*mult),
+        });
+    }
 }
 
 fn enumerate_devices(sock: &NlSocket) -> io::Result<Vec<RdmaDev>> {

--- a/src/stat.rs
+++ b/src/stat.rs
@@ -90,11 +90,13 @@ fn parse_port_stat(nlmsg: &NlMsg) -> Option<PortStat> {
     Some(stat)
 }
 
-// Standard IB port counters in /sys/class/infiniband/<dev>/ports/<n>/counters/
-// are exposed by every RDMA provider. Mellanox doesn't publish tx_bytes/rx_bytes
-// as hw_counters (those are Broadcom-specific), so we synthesize them here
-// from the standard names. Data fields are in 4-byte words per IB spec.
-const SYSFS_FALLBACK: &[(&str, &str, u64)] = &[
+// Names whose values in /sys/.../counters/ are in 4-byte words per IB spec.
+const SYSFS_DATA_COUNTERS: &[&str] = &["port_xmit_data", "port_rcv_data"];
+
+// rdmatop-canonical names synthesized from the standard sysfs counters so the
+// throughput row works for providers that don't expose tx_bytes/rx_bytes as
+// hw_counters (e.g., Mellanox mlx5).
+const SYSFS_SYNTH: &[(&str, &str, u64)] = &[
     ("tx_bytes", "port_xmit_data", 4),
     ("rx_bytes", "port_rcv_data", 4),
     ("tx_pkts", "port_xmit_packets", 1),
@@ -102,23 +104,59 @@ const SYSFS_FALLBACK: &[(&str, &str, u64)] = &[
 ];
 
 fn fill_missing_from_sysfs(stat: &mut PortStat) {
-    for (synth_name, file, mult) in SYSFS_FALLBACK {
+    let dir = format!(
+        "/sys/class/infiniband/{}/ports/{}/counters",
+        stat.dev_name, stat.port
+    );
+
+    // Ingest every standard IB port counter that the driver exposes via sysfs
+    // (link_downed, port_xmit_discards, port_xmit_wait, port_rcv_errors, ...).
+    // These are not surfaced by RDMA netlink, so iproute2's `rdma statistic`
+    // misses them too.
+    if let Ok(entries) = std::fs::read_dir(&dir) {
+        for entry in entries.flatten() {
+            let Some(name) = entry.file_name().to_str().map(String::from) else {
+                continue;
+            };
+            if stat.counters.iter().any(|c| c.name == name) {
+                continue;
+            }
+            let Ok(raw) = std::fs::read_to_string(entry.path()) else {
+                continue;
+            };
+            let Ok(v) = raw.trim().parse::<u64>() else {
+                continue;
+            };
+            let value = if SYSFS_DATA_COUNTERS.contains(&name.as_str()) {
+                v.saturating_mul(4)
+            } else {
+                v
+            };
+            stat.counters.push(HwCounter { name, value });
+        }
+    }
+
+    // Synthesize canonical {tx,rx}_{bytes,pkts} from the standard names so the
+    // top-level throughput row lights up even when the driver doesn't publish
+    // them under those names.
+    for (synth_name, src_name, mult) in SYSFS_SYNTH {
         if stat.counters.iter().any(|c| c.name == *synth_name) {
             continue;
         }
-        let path = format!(
-            "/sys/class/infiniband/{}/ports/{}/counters/{}",
-            stat.dev_name, stat.port, file
-        );
-        let Ok(raw) = std::fs::read_to_string(&path) else {
+        let Some(src) = stat.counters.iter().find(|c| c.name == *src_name) else {
             continue;
         };
-        let Ok(v) = raw.trim().parse::<u64>() else {
-            continue;
+        // src value is already in bytes (we converted port_*_data above), so
+        // for bytes counters mult is 1 in effect. Keep the mult only for
+        // names whose source hasn't been pre-converted.
+        let base = if SYSFS_DATA_COUNTERS.contains(src_name) {
+            src.value
+        } else {
+            src.value.saturating_mul(*mult)
         };
         stat.counters.push(HwCounter {
             name: (*synth_name).to_string(),
-            value: v.saturating_mul(*mult),
+            value: base,
         });
     }
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -22,6 +22,7 @@ pub struct PortThroughput {
 #[derive(Clone, Debug)]
 pub struct CounterRate {
     pub name: String,
+    pub value: u64,
     pub delta: u64,
     pub rate: f64,
     pub is_bytes: bool,
@@ -212,6 +213,7 @@ impl RollingAvgState {
         if n == 0 {
             return CounterRate {
                 name: cr.name.clone(),
+                value: cr.value,
                 delta: 0,
                 rate: 0.0,
                 is_bytes: cr.is_bytes,
@@ -219,8 +221,10 @@ impl RollingAvgState {
         }
         let sum_rate: f64 = present.iter().map(|r| r.rate).sum();
         let sum_delta: u64 = present.iter().map(|r| r.delta).sum();
+        let latest_value = present.last().map(|r| r.value).unwrap_or(cr.value);
         CounterRate {
             name: cr.name.clone(),
+            value: latest_value,
             delta: sum_delta / n as u64,
             rate: sum_rate / n as f64,
             is_bytes: cr.is_bytes,
@@ -687,6 +691,7 @@ fn compute_counter_rate(
     let delta = curr_val.saturating_sub(prev_val);
     CounterRate {
         name: counter_name.to_string(),
+        value: curr_val,
         delta,
         rate: delta as f64 / elapsed,
         is_bytes: is_bytes_counter(counter_name),

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -494,11 +494,25 @@ fn build_device_header(
 }
 
 fn append_active_counters(lines: &mut Vec<Line<'static>>, t: &PortThroughput, tc: &ThemeColors) {
-    let counters: Vec<_> = t
+    // Show every counter that's actually carrying signal:
+    //   - currently changing (delta/rate > 0), or
+    //   - has accumulated some non-zero value, or
+    //   - is in the curated EXTRA_COUNTERS list (always shown for visibility).
+    // This surfaces useful Mellanox metrics like rnr_nak_retry_err, link_downed,
+    // port_xmit_discards, etc. that the previous allow-list filter hid.
+    let mut counters: Vec<_> = t
         .counter_rates
         .iter()
-        .filter(|r| EXTRA_COUNTERS.contains(&r.name.as_str()))
+        .filter(|r| r.value > 0 || EXTRA_COUNTERS.contains(&r.name.as_str()))
         .collect();
+    // Most useful first: active rates, then accumulated, then alphabetical.
+    counters.sort_by(|a, b| {
+        b.rate
+            .partial_cmp(&a.rate)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then(b.value.cmp(&a.value))
+            .then(a.name.cmp(&b.name))
+    });
     if !counters.is_empty() {
         for r in &counters {
             lines.push(counter_rate_line(r, tc));


### PR DESCRIPTION
## Summary 

- Fixes #12 — rdmatop showed zero traffic for Mellanox `mlx5_*` HCAs (incl. H200 hosts) because the driver doesn't publish `tx_bytes`/`rx_bytes` as RDMA-netlink hw_counters.

## What was broken 

`rdma statistic show` (and rdmatop, which reads the same RDMA netlink path) only surfaces hw_counters the driver registers. Mellanox `mlx5` registers RoCE-specific counters (`rx_write_requests`, `np_cnp_sent`, `rnr_nak_retry_err`, …) but **not** `tx_bytes`/`rx_bytes`/`tx_pkts`/`rx_pkts`. The detail view also filtered counters by a hardcoded allow-list that didn't include any Mellanox counter names, so even useful Mellanox stats like rnr_nak_retry_err that were collected via netlink never appeared on screen.