### PR TITLE
stat: add erdma hw_counter alias mapping for throughput display

### DIFF
--- a/src/stat.rs
+++ b/src/stat.rs
@@ -114,6 +114,16 @@ const SYSFS_SYNTH: &[(&str, &str, u64)] = &[
     ("rx_pkts", "port_rcv_packets", 1),
 ];
 
+// Alias mapping for erdma which exposes hw counters under names like
+// hw_tx_bytes_cnt instead of the canonical tx_bytes.
+const HW_COUNTER_ALIASES: &[(&str, &str)] = &[
+    ("tx_bytes", "hw_tx_bytes_cnt"),
+    ("rx_bytes", "hw_rx_bytes_cnt"),
+    ("tx_pkts", "hw_tx_packets_cnt"),
+    ("rx_pkts", "hw_rx_packets_cnt"),
+    ("rx_drops", "hw_rx_disable_drop_cnt"),
+];
+
 fn fill_missing_from_sysfs(stat: &mut PortStat) {
     let dir = format!(
         "/sys/class/infiniband/{}/ports/{}/counters",
@@ -169,6 +179,21 @@ fn fill_missing_from_sysfs(stat: &mut PortStat) {
             name: (*synth_name).to_string(),
             value: base,
         });
+    }
+
+    // Alias hw_counter names for providers like erdma that use
+    // hw_tx_bytes_cnt instead of the canonical tx_bytes.
+    for (canonical, alias) in HW_COUNTER_ALIASES {
+        if stat.counters.iter().any(|c| c.name == *canonical) {
+            continue;
+        }
+        if let Some(src) = stat.counters.iter().find(|c| c.name == *alias) {
+            let value = src.value;
+            stat.counters.push(HwCounter {
+                name: canonical.to_string(),
+                value,
+            });
+        }
     }
 }
 


### PR DESCRIPTION
## Problem

rdmatop expects canonical counter names (`tx_bytes`, `rx_bytes`, `tx_pkts`, `rx_pkts`, `rx_drops`) for the throughput summary row. However, Alibaba Cloud erdma exposes hw counters under different names:

- `hw_tx_bytes_cnt` instead of `tx_bytes`
- `hw_rx_bytes_cnt` instead of `rx_bytes`
- `hw_tx_packets_cnt` instead of `tx_pkts`
- `hw_rx_packets_cnt` instead of `rx_pkts`
- `hw_rx_disable_drop_cnt` instead of `rx_drops`

This causes the RDMA Throughput row to always show 0.00 Gbps on erdma devices, even though all counters are correctly read and displayed in the detail panel.

## Solution

Add a `HW_COUNTER_ALIASES` table in `stat.rs` that maps erdma-style counter names to canonical names. The alias resolution runs after sysfs synthesis, so it won't conflict with providers that already use canonical names (e.g., EFA, mlx5).

## Testing

Tested on Alibaba Cloud ECS with erdma_0/erdma_1 devices:
- Before: throughput summary shows 0.00 Gbps, detail panel shows all hw counters
- After: throughput summary correctly reflects erdma traffic, detail panel shows both original and aliased counters

Signed-off-by: Cheng Xu <chengyou@linux.alibaba.com>