### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ppa-publish.yml
+++ b/.github/workflows/ppa-publish.yml
@@ -1,5 +1,8 @@
 name: Publish to Launchpad PPA
 
+permissions:
+  contents: read
+
 on:
   push:
     tags: ["v*"]


### PR DESCRIPTION
Potential fix for [https://github.com/uccl-project/rdmatop/security/code-scanning/3](https://github.com/uccl-project/rdmatop/security/code-scanning/3)

Add an explicit top-level `permissions` block to the workflow so all jobs inherit least-privilege token access.  
Best single fix here (without changing behavior) is:

- In `.github/workflows/ppa-publish.yml`, insert right after `name:` (before `on:`):
  - `permissions:`
  - `contents: read`

This is sufficient for `actions/checkout` and does not grant unnecessary write scopes. No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
