### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ppa-publish.yml
+++ b/.github/workflows/ppa-publish.yml
@@ -13,6 +13,9 @@ on:
         required: false
         default: "resolute,noble,jammy"
 
+permissions:
+  contents: read
+
 jobs:
   resolve:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Potential fix for [https://github.com/uccl-project/rdmatop/security/code-scanning/2](https://github.com/uccl-project/rdmatop/security/code-scanning/2)

Add an explicit top-level `permissions` block in `.github/workflows/ppa-publish.yml` so all jobs inherit minimal required token scopes.

Best fix here (without changing behavior): define workflow-level permissions as read-only for repository contents:

- Add under the trigger section (`on:` block), before `jobs:`
- Use:
  - `contents: read`

This is sufficient for `actions/checkout` to read the repo and does not grant unnecessary write scopes. No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
