### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/uccl-project/rdmatop/security/code-scanning/1](https://github.com/uccl-project/rdmatop/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/ci.yml` at the workflow root (top-level), so it applies to all jobs unless overridden. For this CI workflow, the least-privilege baseline is:

- `contents: read`

This preserves current behavior (checkout/build/test/lint) while ensuring the token cannot write unless explicitly granted later.

Change location:
- In `.github/workflows/ci.yml`, insert the `permissions` block between the `on:` trigger section and `jobs:`.

No imports, methods, or extra definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
