### PR TITLE
Add Nvlink Surpport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -296,3 +296,4 @@ tags
 [._]*.un~
 .cargo/
 vendor/
+.worktrees/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,9 @@ repository = "https://github.com/uccl-project/rdmatop"
 keywords = ["rdma", "efa", "networking", "tui", "infiniband"]
 categories = ["network-programming", "command-line-utilities"]
 
+[features]
+nvlink = ["dep:nvml-wrapper", "dep:nvml-wrapper-sys"]
+
 [profile.release]
 strip = true
 
@@ -22,3 +25,5 @@ assets = [
 libc = "0.2"
 ratatui = "0.30"
 crossterm = "0.29"
+nvml-wrapper = { version = "0.12.1", optional = true }
+nvml-wrapper-sys = { version = "0.9.1", optional = true }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,9 @@ mod stat;
 mod trace;
 mod tui;
 
+#[cfg(feature = "nvlink")]
+mod nvlink;
+
 use std::io;
 use std::time::Instant;
 

--- a/src/nvlink.rs
+++ b/src/nvlink.rs
@@ -93,6 +93,8 @@ pub struct NvLinkSnapshot {
     /// Negotiated aggregate speed in Gbps, derived from the per-link
     /// `NVML_FI_DEV_NVLINK_SPEED_MBPS_COMMON` field when available.
     pub link_gbps: Option<f64>,
+    pub tx_bytes: Option<u64>,
+    pub rx_bytes: Option<u64>,
     pub links: Vec<LinkSnapshot>,
 }
 
@@ -192,6 +194,8 @@ fn read_device_snapshot(nvml: &Nvml, idx: u32) -> Option<NvLinkSnapshot> {
         });
     }
 
+    let (tx_bytes, rx_bytes) = read_link_throughput(nvml, &device, u32::MAX);
+
     Some(NvLinkSnapshot {
         gpu_index: idx,
         gpu_name,
@@ -201,6 +205,8 @@ fn read_device_snapshot(nvml: &Nvml, idx: u32) -> Option<NvLinkSnapshot> {
         } else {
             None
         },
+        tx_bytes,
+        rx_bytes,
         links,
     })
 }
@@ -290,14 +296,14 @@ fn read_link_throughput(
     let tx_bytes = if tx.nvmlReturn == 0
         && tx.valueType == nvmlValueType_enum_NVML_VALUE_TYPE_UNSIGNED_LONG_LONG
     {
-        Some(unsafe { tx.value.ullVal })
+        Some(unsafe { tx.value.ullVal }.wrapping_mul(1024))
     } else {
         None
     };
     let rx_bytes = if rx.nvmlReturn == 0
         && rx.valueType == nvmlValueType_enum_NVML_VALUE_TYPE_UNSIGNED_LONG_LONG
     {
-        Some(unsafe { rx.value.ullVal })
+        Some(unsafe { rx.value.ullVal }.wrapping_mul(1024))
     } else {
         None
     };
@@ -343,6 +349,8 @@ mod tests {
             gpu_name: "test".to_string(),
             link_count: 4,
             link_gbps: None,
+            tx_bytes: None,
+            rx_bytes: None,
             links: vec![
                 LinkSnapshot {
                     link_id: 0,
@@ -395,6 +403,8 @@ mod tests {
             gpu_name: "test".to_string(),
             link_count: 0,
             link_gbps: None,
+            tx_bytes: None,
+            rx_bytes: None,
             links: Vec::new(),
         };
         assert_eq!(snap.active_links(), 0);

--- a/src/nvlink.rs
+++ b/src/nvlink.rs
@@ -1,0 +1,402 @@
+//! NVLink data layer built on top of the NVIDIA Management Library (NVML).
+//!
+//! This module is only compiled when the `nvlink` cargo feature is enabled.
+//! It exposes a small snapshot type that the TUI can render without having to
+//! link directly against NVML. Per-link TX/RX throughput is read via the raw
+//! `nvmlDeviceGetFieldValues` entry point because `nvml-wrapper` does not
+//! currently expose a safe helper for those field IDs.
+
+use std::io;
+
+use nvml_wrapper::enum_wrappers::nv_link::{ErrorCounter, IntDeviceType};
+use nvml_wrapper::enums::device::SampleValue;
+use nvml_wrapper::structs::device::FieldId;
+use nvml_wrapper::Nvml;
+
+use nvml_wrapper_sys::bindings::field_id::{
+    NVML_FI_DEV_NVLINK_LINK_COUNT, NVML_FI_DEV_NVLINK_SPEED_MBPS_COMMON,
+    NVML_FI_DEV_NVLINK_SPEED_MBPS_L0, NVML_FI_DEV_NVLINK_SPEED_MBPS_L1,
+    NVML_FI_DEV_NVLINK_SPEED_MBPS_L10, NVML_FI_DEV_NVLINK_SPEED_MBPS_L11,
+    NVML_FI_DEV_NVLINK_SPEED_MBPS_L2, NVML_FI_DEV_NVLINK_SPEED_MBPS_L3,
+    NVML_FI_DEV_NVLINK_SPEED_MBPS_L4, NVML_FI_DEV_NVLINK_SPEED_MBPS_L5,
+    NVML_FI_DEV_NVLINK_SPEED_MBPS_L6, NVML_FI_DEV_NVLINK_SPEED_MBPS_L7,
+    NVML_FI_DEV_NVLINK_SPEED_MBPS_L8, NVML_FI_DEV_NVLINK_SPEED_MBPS_L9,
+    NVML_FI_DEV_NVLINK_THROUGHPUT_DATA_RX, NVML_FI_DEV_NVLINK_THROUGHPUT_DATA_TX,
+};
+use nvml_wrapper_sys::bindings::{
+    nvmlFieldValue_st, nvmlValueType_enum_NVML_VALUE_TYPE_UNSIGNED_LONG_LONG, nvmlValue_t,
+    NVML_NVLINK_MAX_LINKS,
+};
+
+/// Logical classification of the device on the other end of an NVLink.
+#[derive(Clone, Debug, PartialEq)]
+pub enum RemoteDeviceType {
+    Gpu,
+    IbmNpu,
+    Switch,
+    Unknown,
+}
+
+impl RemoteDeviceType {
+    /// Short, human-readable label used by the TUI.
+    pub fn label(&self) -> &'static str {
+        match self {
+            RemoteDeviceType::Gpu => "GPU",
+            RemoteDeviceType::IbmNpu => "NPU",
+            RemoteDeviceType::Switch => "NVSwitch",
+            RemoteDeviceType::Unknown => "?",
+        }
+    }
+}
+
+impl From<IntDeviceType> for RemoteDeviceType {
+    fn from(value: IntDeviceType) -> Self {
+        match value {
+            IntDeviceType::Gpu => RemoteDeviceType::Gpu,
+            IntDeviceType::Ibmnpu => RemoteDeviceType::IbmNpu,
+            IntDeviceType::Switch => RemoteDeviceType::Switch,
+            IntDeviceType::Unknown => RemoteDeviceType::Unknown,
+        }
+    }
+}
+
+/// Snapshot of a single NVLink's state at one sample.
+#[derive(Clone, Debug)]
+pub struct LinkSnapshot {
+    pub link_id: u32,
+    /// True if NVML reports the link as active (NVLink state enabled).
+    pub is_active: bool,
+    /// NVLink protocol version reported by the driver.
+    pub version: Option<u32>,
+    /// Negotiated per-link speed in Gbps (Mb/s / 1000). `None` if unknown.
+    /// Aggregated into `NvLinkSnapshot::link_gbps` for the GPU-wide total;
+    /// not directly read by the TUI.
+    #[allow(dead_code)]
+    pub speed_gbps: Option<f64>,
+    pub remote_device_type: RemoteDeviceType,
+    /// BDF of the remote PCI device, if NVML reports one.
+    pub remote_pci_bdf: Option<String>,
+    pub tx_bytes: Option<u64>,
+    pub rx_bytes: Option<u64>,
+    pub crc_error_count: Option<u64>,
+    pub replay_error_count: Option<u64>,
+    pub recovery_error_count: Option<u64>,
+}
+
+/// Snapshot of every NVLink attached to one GPU.
+#[derive(Clone, Debug)]
+pub struct NvLinkSnapshot {
+    pub gpu_index: u32,
+    pub gpu_name: String,
+    /// Total number of NVLink ports exposed by the GPU (active + inactive).
+    pub link_count: u32,
+    /// Negotiated aggregate speed in Gbps, derived from the per-link
+    /// `NVML_FI_DEV_NVLINK_SPEED_MBPS_COMMON` field when available.
+    pub link_gbps: Option<f64>,
+    pub links: Vec<LinkSnapshot>,
+}
+
+impl NvLinkSnapshot {
+    /// Count of links that NVML currently reports as active.
+    pub fn active_links(&self) -> u32 {
+        self.links.iter().filter(|l| l.is_active).count() as u32
+    }
+}
+
+/// Per-link speed field IDs in the order used by `read_link_speed_gbps`.
+const LINK_SPEED_FIELD_IDS: [u32; 12] = [
+    NVML_FI_DEV_NVLINK_SPEED_MBPS_L0,
+    NVML_FI_DEV_NVLINK_SPEED_MBPS_L1,
+    NVML_FI_DEV_NVLINK_SPEED_MBPS_L2,
+    NVML_FI_DEV_NVLINK_SPEED_MBPS_L3,
+    NVML_FI_DEV_NVLINK_SPEED_MBPS_L4,
+    NVML_FI_DEV_NVLINK_SPEED_MBPS_L5,
+    NVML_FI_DEV_NVLINK_SPEED_MBPS_L6,
+    NVML_FI_DEV_NVLINK_SPEED_MBPS_L7,
+    NVML_FI_DEV_NVLINK_SPEED_MBPS_L8,
+    NVML_FI_DEV_NVLINK_SPEED_MBPS_L9,
+    NVML_FI_DEV_NVLINK_SPEED_MBPS_L10,
+    NVML_FI_DEV_NVLINK_SPEED_MBPS_L11,
+];
+
+/// Read NVLink statistics for every GPU in the system.
+///
+/// If NVML cannot be initialised (e.g. no NVIDIA driver loaded), an empty
+/// vector is returned so the caller can keep running with no NVLink data.
+/// Per-GPU or per-link failures are skipped silently and the remaining data
+/// is still returned.
+pub fn read_all_nvlink_stats() -> io::Result<Vec<NvLinkSnapshot>> {
+    let nvml = match Nvml::init() {
+        Ok(n) => n,
+        Err(_) => return Ok(Vec::new()),
+    };
+
+    let device_count = match nvml.device_count() {
+        Ok(c) => c,
+        Err(_) => return Ok(Vec::new()),
+    };
+
+    let mut snapshots = Vec::with_capacity(device_count as usize);
+    for idx in 0..device_count {
+        if let Some(snap) = read_device_snapshot(&nvml, idx) {
+            snapshots.push(snap);
+        }
+    }
+
+    Ok(snapshots)
+}
+
+fn read_device_snapshot(nvml: &Nvml, idx: u32) -> Option<NvLinkSnapshot> {
+    let device = nvml.device_by_index(idx).ok()?;
+    let gpu_name = device.name().unwrap_or_default();
+
+    let link_count = read_link_count(&device).unwrap_or(NVML_NVLINK_MAX_LINKS);
+    let common_speed_gbps = read_common_speed_gbps(&device);
+
+    let mut total_speed_gbps = 0.0;
+    let mut links = Vec::with_capacity(link_count as usize);
+    for link_id in 0..link_count {
+        let nvlink = device.link_wrapper_for(link_id);
+        let is_active = nvlink.is_active().unwrap_or(false);
+        let version = nvlink.version().ok();
+        let remote_device_type = nvlink
+            .remote_device_type(link_id)
+            .map(RemoteDeviceType::from)
+            .unwrap_or(RemoteDeviceType::Unknown);
+        let remote_pci_bdf = nvlink.remote_pci_info().ok().map(|p| p.bus_id);
+        let crc_error_count = nvlink.error_counter(ErrorCounter::DlCrcFlit).ok();
+        let replay_error_count = nvlink.error_counter(ErrorCounter::DlReplay).ok();
+        let recovery_error_count = nvlink.error_counter(ErrorCounter::DlRecovery).ok();
+        let (tx_bytes, rx_bytes) = read_link_throughput(nvml, &device, link_id);
+        let speed_gbps = if is_active {
+            read_link_speed_gbps(&device, link_id).or(common_speed_gbps)
+        } else {
+            None
+        };
+        if let Some(s) = speed_gbps {
+            total_speed_gbps += s;
+        }
+
+        links.push(LinkSnapshot {
+            link_id,
+            is_active,
+            version,
+            speed_gbps,
+            remote_device_type,
+            remote_pci_bdf,
+            tx_bytes,
+            rx_bytes,
+            crc_error_count,
+            replay_error_count,
+            recovery_error_count,
+        });
+    }
+
+    Some(NvLinkSnapshot {
+        gpu_index: idx,
+        gpu_name,
+        link_count,
+        link_gbps: if total_speed_gbps > 0.0 {
+            Some(total_speed_gbps)
+        } else {
+            None
+        },
+        links,
+    })
+}
+
+/// Build a fresh `nvmlFieldValue_t` populated with `fieldId` and `scopeId`.
+fn make_field(field_id: u32, scope_id: u32) -> nvmlFieldValue_st {
+    nvmlFieldValue_st {
+        fieldId: field_id,
+        scopeId: scope_id,
+        timestamp: 0,
+        latencyUsec: 0,
+        valueType: 0,
+        nvmlReturn: 0,
+        value: nvmlValue_t { ullVal: 0 },
+    }
+}
+
+/// Read a single NVML field via the safe `field_values_for` API.
+/// Returns `Some(u32)` only when the field is reported as `U32`.
+fn read_field_u32(device: &nvml_wrapper::Device<'_>, field_id: u32) -> Option<u32> {
+    let results = device.field_values_for(&[FieldId(field_id)]).ok()?;
+    let sample = results.into_iter().next()?.ok()?;
+    match sample.value.ok()? {
+        SampleValue::U32(v) => Some(v),
+        _ => None,
+    }
+}
+
+fn read_link_count(device: &nvml_wrapper::Device<'_>) -> Option<u32> {
+    read_field_u32(device, NVML_FI_DEV_NVLINK_LINK_COUNT)
+}
+
+fn read_common_speed_gbps(device: &nvml_wrapper::Device<'_>) -> Option<f64> {
+    let mbps = read_field_u32(device, NVML_FI_DEV_NVLINK_SPEED_MBPS_COMMON)?;
+    if mbps == 0 {
+        None
+    } else {
+        // NVML reports Mb/s (megabits/sec) for this field; convert to Gb/s.
+        Some(mbps as f64 / 1000.0)
+    }
+}
+
+fn read_link_speed_gbps(device: &nvml_wrapper::Device<'_>, link: u32) -> Option<f64> {
+    let field_id = *LINK_SPEED_FIELD_IDS.get(link as usize)?;
+    let mbps = read_field_u32(device, field_id)?;
+    if mbps == 0 {
+        None
+    } else {
+        // NVML reports Mb/s (megabits/sec); convert to Gb/s.
+        Some(mbps as f64 / 1000.0)
+    }
+}
+
+/// Query per-link TX/RX throughput via raw `nvmlDeviceGetFieldValues`.
+/// `scopeId` is set to the per-link id as required by the plan.
+fn read_link_throughput(
+    nvml: &Nvml,
+    device: &nvml_wrapper::Device<'_>,
+    link: u32,
+) -> (Option<u64>, Option<u64>) {
+    let mut tx = make_field(NVML_FI_DEV_NVLINK_THROUGHPUT_DATA_TX, link);
+    let mut rx = make_field(NVML_FI_DEV_NVLINK_THROUGHPUT_DATA_RX, link);
+
+    let mut fields = [tx, rx];
+    let rc = unsafe {
+        nvml.lib().nvmlDeviceGetFieldValues(
+            device.handle(),
+            fields.len() as std::os::raw::c_int,
+            fields.as_mut_ptr(),
+        )
+    };
+    // `nvmlReturn_t` is a type alias for `u32` in the NVML bindings, so the
+    // SUCCESS value is the literal 0; comparisons against the typed variant
+    // are not available.
+    if rc != 0 {
+        return (None, None);
+    }
+    tx = fields[0];
+    rx = fields[1];
+
+    // NVML does not actually let you scope these throughput counters to a
+    // single link via `scopeId`; the driver always reports the per-GPU
+    // aggregate. The values below therefore represent the GPU aggregate
+    // rather than the per-link bytes. Per-link attribution would require a
+    // future NVML field; until then we return whatever NVML gives us so the
+    // TUI can at least show a non-zero value when traffic is flowing.
+    let tx_bytes = if tx.nvmlReturn == 0
+        && tx.valueType == nvmlValueType_enum_NVML_VALUE_TYPE_UNSIGNED_LONG_LONG
+    {
+        Some(unsafe { tx.value.ullVal })
+    } else {
+        None
+    };
+    let rx_bytes = if rx.nvmlReturn == 0
+        && rx.valueType == nvmlValueType_enum_NVML_VALUE_TYPE_UNSIGNED_LONG_LONG
+    {
+        Some(unsafe { rx.value.ullVal })
+    } else {
+        None
+    };
+    (tx_bytes, rx_bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn remote_device_type_label() {
+        assert_eq!(RemoteDeviceType::Gpu.label(), "GPU");
+        assert_eq!(RemoteDeviceType::IbmNpu.label(), "NPU");
+        assert_eq!(RemoteDeviceType::Switch.label(), "NVSwitch");
+        assert_eq!(RemoteDeviceType::Unknown.label(), "?");
+    }
+
+    #[test]
+    fn remote_device_type_from_int_device_type() {
+        assert_eq!(
+            RemoteDeviceType::from(IntDeviceType::Gpu),
+            RemoteDeviceType::Gpu
+        );
+        assert_eq!(
+            RemoteDeviceType::from(IntDeviceType::Ibmnpu),
+            RemoteDeviceType::IbmNpu
+        );
+        assert_eq!(
+            RemoteDeviceType::from(IntDeviceType::Switch),
+            RemoteDeviceType::Switch
+        );
+        assert_eq!(
+            RemoteDeviceType::from(IntDeviceType::Unknown),
+            RemoteDeviceType::Unknown
+        );
+    }
+
+    #[test]
+    fn active_links_counts_active_only() {
+        let snap = NvLinkSnapshot {
+            gpu_index: 0,
+            gpu_name: "test".to_string(),
+            link_count: 4,
+            link_gbps: None,
+            links: vec![
+                LinkSnapshot {
+                    link_id: 0,
+                    is_active: true,
+                    version: None,
+                    speed_gbps: None,
+                    remote_device_type: RemoteDeviceType::Gpu,
+                    remote_pci_bdf: None,
+                    tx_bytes: None,
+                    rx_bytes: None,
+                    crc_error_count: None,
+                    replay_error_count: None,
+                    recovery_error_count: None,
+                },
+                LinkSnapshot {
+                    link_id: 1,
+                    is_active: false,
+                    version: None,
+                    speed_gbps: None,
+                    remote_device_type: RemoteDeviceType::Unknown,
+                    remote_pci_bdf: None,
+                    tx_bytes: None,
+                    rx_bytes: None,
+                    crc_error_count: None,
+                    replay_error_count: None,
+                    recovery_error_count: None,
+                },
+                LinkSnapshot {
+                    link_id: 2,
+                    is_active: true,
+                    version: None,
+                    speed_gbps: None,
+                    remote_device_type: RemoteDeviceType::Switch,
+                    remote_pci_bdf: None,
+                    tx_bytes: None,
+                    rx_bytes: None,
+                    crc_error_count: None,
+                    replay_error_count: None,
+                    recovery_error_count: None,
+                },
+            ],
+        };
+        assert_eq!(snap.active_links(), 2);
+    }
+
+    #[test]
+    fn active_links_no_links() {
+        let snap = NvLinkSnapshot {
+            gpu_index: 0,
+            gpu_name: "test".to_string(),
+            link_count: 0,
+            link_gbps: None,
+            links: Vec::new(),
+        };
+        assert_eq!(snap.active_links(), 0);
+    }
+}

--- a/src/nvlink.rs
+++ b/src/nvlink.rs
@@ -161,10 +161,7 @@ fn read_device_snapshot(nvml: &Nvml, idx: u32) -> Option<NvLinkSnapshot> {
         let nvlink = device.link_wrapper_for(link_id);
         let is_active = nvlink.is_active().unwrap_or(false);
         let version = nvlink.version().ok();
-        let remote_device_type = nvlink
-            .remote_device_type(link_id)
-            .map(RemoteDeviceType::from)
-            .unwrap_or(RemoteDeviceType::Unknown);
+        let remote_device_type = read_remote_device_type(nvml, &device, link_id);
         let remote_pci_bdf = nvlink.remote_pci_info().ok().map(|p| p.bus_id);
         let crc_error_count = nvlink.error_counter(ErrorCounter::DlCrcFlit).ok();
         let replay_error_count = nvlink.error_counter(ErrorCounter::DlReplay).ok();
@@ -308,6 +305,36 @@ fn read_link_throughput(
         None
     };
     (tx_bytes, rx_bytes)
+}
+
+#[allow(non_upper_case_globals)]
+fn read_remote_device_type(
+    nvml: &Nvml,
+    device: &nvml_wrapper::Device<'_>,
+    link: u32,
+) -> RemoteDeviceType {
+    use nvml_wrapper_sys::bindings::{
+        nvmlIntNvLinkDeviceType_enum_NVML_NVLINK_DEVICE_TYPE_GPU,
+        nvmlIntNvLinkDeviceType_enum_NVML_NVLINK_DEVICE_TYPE_IBMNPU,
+        nvmlIntNvLinkDeviceType_enum_NVML_NVLINK_DEVICE_TYPE_SWITCH, nvmlIntNvLinkDeviceType_t,
+    };
+
+    let mut dev_type: nvmlIntNvLinkDeviceType_t = 255;
+    let rc = unsafe {
+        nvml.lib()
+            .nvmlDeviceGetNvLinkRemoteDeviceType(device.handle(), link, &mut dev_type)
+    };
+
+    if rc == 0 {
+        match dev_type {
+            nvmlIntNvLinkDeviceType_enum_NVML_NVLINK_DEVICE_TYPE_GPU => RemoteDeviceType::Gpu,
+            nvmlIntNvLinkDeviceType_enum_NVML_NVLINK_DEVICE_TYPE_IBMNPU => RemoteDeviceType::IbmNpu,
+            nvmlIntNvLinkDeviceType_enum_NVML_NVLINK_DEVICE_TYPE_SWITCH => RemoteDeviceType::Switch,
+            _ => RemoteDeviceType::Unknown,
+        }
+    } else {
+        RemoteDeviceType::Unknown
+    }
 }
 
 #[cfg(test)]

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -20,6 +20,31 @@ pub struct PortThroughput {
     pub rx_pkts_per_sec: f64,
     pub rx_drops_per_sec: f64,
     pub counter_rates: Vec<CounterRate>,
+    /// Optional override for the Port column text. Used by NVLink rows.
+    pub port_label: Option<String>,
+    /// NVLink metadata attached to this row. Populated by Task 3 and rendered
+    /// by the TUI detail pane when the `nvlink` feature is enabled.
+    #[cfg(feature = "nvlink")]
+    pub nvlink: Option<NvLinkThroughputMeta>,
+}
+
+/// Per-GPU NVLink metadata attached to a `PortThroughput` row when the
+/// `nvlink` feature is enabled. The TUI uses this to show per-link details
+/// and error counters in the detail pane.
+#[cfg(feature = "nvlink")]
+#[derive(Clone, Debug)]
+pub struct NvLinkThroughputMeta {
+    /// GPU index reported by NVML. Not directly rendered by the TUI today
+    /// (the row already shows `nvidia<index>` via `PortThroughput::dev_name`)
+    /// but kept so future panels (e.g. topology graph) can reference it.
+    #[allow(dead_code)]
+    pub gpu_index: u32,
+    /// Marketing name of the GPU (e.g. "H100"). Currently unused by the
+    /// detail pane, which displays only the aggregate active/total counts.
+    #[allow(dead_code)]
+    pub gpu_name: String,
+    pub active_links: u32,
+    pub links: Vec<crate::nvlink::LinkSnapshot>,
 }
 
 #[derive(Clone, Debug)]
@@ -156,7 +181,7 @@ impl RollingAvgState {
     pub fn push(&mut self, throughputs: &[PortThroughput]) {
         let mut seen = std::collections::HashSet::new();
         for t in throughputs {
-            let key = format!("{}/{}", t.dev_name, t.port);
+            let key = throughput_key(t);
             seen.insert(key.clone());
             let buf = self
                 .samples
@@ -189,17 +214,25 @@ impl RollingAvgState {
         let start = buf.len().saturating_sub(window_secs);
         let window: Vec<_> = buf.iter().skip(start).collect();
         let n = window.len() as f64;
-        let first = window[0];
+        // Copy metadata from the latest sample. For NVLink rows, the oldest
+        // sample's `port`/`port_label` may reflect a stale active-link count;
+        // using the latest keeps the averaged row's metadata fresh.
+        // `nvlink` is also metadata; preserving it lets `throughput_key`
+        // identify averaged NVLink rows by `dev_name` alone.
+        let latest = window.last().unwrap();
         let mut avg = PortThroughput {
-            dev_name: first.dev_name.clone(),
-            port: first.port,
-            link_gbps: first.link_gbps,
+            dev_name: latest.dev_name.clone(),
+            port: latest.port,
+            link_gbps: latest.link_gbps,
             tx_gbps: window.iter().map(|s| s.tx_gbps).sum::<f64>() / n,
             rx_gbps: window.iter().map(|s| s.rx_gbps).sum::<f64>() / n,
             tx_pkts_per_sec: window.iter().map(|s| s.tx_pkts_per_sec).sum::<f64>() / n,
             rx_pkts_per_sec: window.iter().map(|s| s.rx_pkts_per_sec).sum::<f64>() / n,
             rx_drops_per_sec: window.iter().map(|s| s.rx_drops_per_sec).sum::<f64>() / n,
             counter_rates: Vec::new(),
+            port_label: latest.port_label.clone(),
+            #[cfg(feature = "nvlink")]
+            nvlink: latest.nvlink.clone(),
         };
         if let Some(template) = window.last() {
             avg.counter_rates = template
@@ -298,6 +331,8 @@ pub struct App {
     pub recorder: Option<Recorder>,
     /// Transient message shown after a recording is saved or fails.
     pub record_status: Option<String>,
+    #[cfg(feature = "nvlink")]
+    prev_nvlink: Vec<crate::nvlink::NvLinkSnapshot>,
 }
 
 const HISTORY_LEN: usize = 60;
@@ -372,6 +407,8 @@ impl App {
             cached_display: Vec::new(),
             recorder: None,
             record_status: None,
+            #[cfg(feature = "nvlink")]
+            prev_nvlink: Vec::new(),
         }
     }
 
@@ -386,6 +423,15 @@ impl App {
         }
         self.throughputs = compute_throughputs(&self.prev_stats, &curr, elapsed);
         self.prev_stats = curr;
+
+        #[cfg(feature = "nvlink")]
+        {
+            let curr_nvlink = crate::nvlink::read_all_nvlink_stats().unwrap_or_default();
+            let mut nvlink_rows =
+                compute_nvlink_throughputs(&self.prev_nvlink, &curr_nvlink, elapsed);
+            self.throughputs.append(&mut nvlink_rows);
+            self.prev_nvlink = curr_nvlink;
+        }
 
         let curr_if = net::read_all_ifstats().unwrap_or_default();
         let net_rate = net::compute_net_rate(&self.prev_ifstats, &curr_if, elapsed);
@@ -814,6 +860,9 @@ fn compute_port_throughput(
         rx_pkts_per_sec: rate_by_name(&counter_rates, "rx_pkts"),
         rx_drops_per_sec: rate_by_name(&counter_rates, "rx_drops"),
         counter_rates,
+        port_label: None,
+        #[cfg(feature = "nvlink")]
+        nvlink: None,
     }
 }
 
@@ -823,17 +872,702 @@ fn compute_throughputs(prev: &[PortStat], curr: &[PortStat], elapsed: f64) -> Ve
         .collect()
 }
 
+/// Stable identity key for a `PortThroughput` row across refreshes.
+///
+/// For NVLink rows the `port` field encodes the active-link count, which can
+/// change between samples even when the underlying GPU is the same. Using
+/// `dev_name` alone keeps the key (and therefore sort order and rolling-avg
+/// history) stable across those changes.
+fn throughput_key(t: &PortThroughput) -> String {
+    #[cfg(feature = "nvlink")]
+    if t.nvlink.is_some() {
+        return t.dev_name.clone();
+    }
+    format!("{}/{}", t.dev_name, t.port)
+}
+
 /// Sort averaged throughputs to match the order of the reference (instant) throughputs,
 /// using an index map for O(n log n) performance.
 fn sort_by_throughput_order(avgs: &mut [PortThroughput], reference: &[PortThroughput]) {
-    let index_map: HashMap<(String, u32), usize> = reference
+    let index_map: HashMap<String, usize> = reference
         .iter()
         .enumerate()
-        .map(|(i, t)| ((t.dev_name.clone(), t.port), i))
+        .map(|(i, t)| (throughput_key(t), i))
         .collect();
-    avgs.sort_by_key(|t| {
-        *index_map
-            .get(&(t.dev_name.clone(), t.port))
-            .unwrap_or(&usize::MAX)
-    });
+    avgs.sort_by_key(|t| *index_map.get(&throughput_key(t)).unwrap_or(&usize::MAX));
+}
+
+/// Compute one `PortThroughput` row per GPU from a pair of NVLink snapshots.
+///
+/// The previous snapshot is looked up by `gpu_index`. Missing previous links
+/// (or `None` byte counters) are treated as zero so a freshly-observed GPU
+/// surfaces its full current byte counts as the first delta.
+///
+/// NVML exposes `NVML_FI_DEV_NVLINK_THROUGHPUT_DATA_TX/RX` as a *GPU-wide*
+/// aggregate, not per-link counters. Each link in `LinkSnapshot::tx_bytes` /
+/// `rx_bytes` therefore carries the same GPU-wide value, so we must read it
+/// exactly once per GPU (from the first active link, or the first link if no
+/// link is active) instead of summing across links. Summing would multiply
+/// the aggregate by the number of active links.
+///
+/// Per-link error `CounterRate`s (crc/replay/recovery) are still emitted for
+/// every link so the detail pane can display per-lane error counts.
+#[cfg(feature = "nvlink")]
+fn compute_nvlink_throughputs(
+    prev: &[crate::nvlink::NvLinkSnapshot],
+    curr: &[crate::nvlink::NvLinkSnapshot],
+    elapsed: f64,
+) -> Vec<PortThroughput> {
+    let mut out = Vec::with_capacity(curr.len());
+    for gpu in curr {
+        let prev_gpu = prev.iter().find(|p| p.gpu_index == gpu.gpu_index);
+        let mut counter_rates: Vec<CounterRate> = Vec::new();
+
+        // Pick a single link to source the GPU-wide TX/RX aggregate from.
+        // Prefer the first active link; if none are active, fall back to the
+        // first link in the list (its counters still represent the GPU).
+        let aggregate_link = gpu
+            .links
+            .iter()
+            .find(|l| l.is_active)
+            .or_else(|| gpu.links.first());
+
+        let (tx_bytes_total, rx_bytes_total) = match aggregate_link {
+            Some(link) => {
+                let prev_link =
+                    prev_gpu.and_then(|p| p.links.iter().find(|l| l.link_id == link.link_id));
+                let curr_tx = link.tx_bytes.unwrap_or(0);
+                let prev_tx = prev_link.and_then(|l| l.tx_bytes).unwrap_or(0);
+                let curr_rx = link.rx_bytes.unwrap_or(0);
+                let prev_rx = prev_link.and_then(|l| l.rx_bytes).unwrap_or(0);
+                (
+                    curr_tx.saturating_sub(prev_tx),
+                    curr_rx.saturating_sub(prev_rx),
+                )
+            }
+            None => (0, 0),
+        };
+
+        for link in &gpu.links {
+            let prev_link =
+                prev_gpu.and_then(|p| p.links.iter().find(|l| l.link_id == link.link_id));
+
+            if let Some(v) = link.crc_error_count {
+                let prev_v = prev_link.and_then(|l| l.crc_error_count).unwrap_or(0);
+                let delta = v.saturating_sub(prev_v);
+                counter_rates.push(CounterRate {
+                    name: format!("nvlink_crc_l{}", link.link_id),
+                    value: v,
+                    delta,
+                    rate: delta as f64 / elapsed,
+                    is_bytes: false,
+                });
+            }
+            if let Some(v) = link.replay_error_count {
+                let prev_v = prev_link.and_then(|l| l.replay_error_count).unwrap_or(0);
+                let delta = v.saturating_sub(prev_v);
+                counter_rates.push(CounterRate {
+                    name: format!("nvlink_replay_l{}", link.link_id),
+                    value: v,
+                    delta,
+                    rate: delta as f64 / elapsed,
+                    is_bytes: false,
+                });
+            }
+            if let Some(v) = link.recovery_error_count {
+                let prev_v = prev_link.and_then(|l| l.recovery_error_count).unwrap_or(0);
+                let delta = v.saturating_sub(prev_v);
+                counter_rates.push(CounterRate {
+                    name: format!("nvlink_recovery_l{}", link.link_id),
+                    value: v,
+                    delta,
+                    rate: delta as f64 / elapsed,
+                    is_bytes: false,
+                });
+            }
+        }
+
+        let active = gpu.active_links();
+        out.push(PortThroughput {
+            dev_name: format!("nvidia{}", gpu.gpu_index),
+            port: active,
+            link_gbps: gpu.link_gbps,
+            tx_gbps: bytes_to_gbps(tx_bytes_total as f64 / elapsed),
+            rx_gbps: bytes_to_gbps(rx_bytes_total as f64 / elapsed),
+            tx_pkts_per_sec: 0.0,
+            rx_pkts_per_sec: 0.0,
+            rx_drops_per_sec: 0.0,
+            counter_rates,
+            port_label: Some(format!("{}/{}", active, gpu.link_count)),
+            nvlink: Some(NvLinkThroughputMeta {
+                gpu_index: gpu.gpu_index,
+                gpu_name: gpu.gpu_name.clone(),
+                active_links: active,
+                links: gpu.links.clone(),
+            }),
+        });
+    }
+    out
+}
+
+#[cfg(all(test, feature = "nvlink"))]
+mod nvlink_tests {
+    use super::*;
+    use crate::nvlink::{LinkSnapshot, NvLinkSnapshot, RemoteDeviceType};
+
+    fn make_link(id: u32, active: bool, tx: Option<u64>, rx: Option<u64>) -> LinkSnapshot {
+        LinkSnapshot {
+            link_id: id,
+            is_active: active,
+            version: None,
+            speed_gbps: if active { Some(50.0) } else { None },
+            remote_device_type: RemoteDeviceType::Gpu,
+            remote_pci_bdf: None,
+            tx_bytes: tx,
+            rx_bytes: rx,
+            crc_error_count: None,
+            replay_error_count: None,
+            recovery_error_count: None,
+        }
+    }
+
+    #[test]
+    fn aggregates_only_active_links_and_sets_port_label() {
+        let elapsed = 1.0_f64;
+
+        let prev = vec![NvLinkSnapshot {
+            gpu_index: 0,
+            gpu_name: "H100".to_string(),
+            link_count: 2,
+            link_gbps: Some(100.0),
+            links: vec![
+                make_link(0, true, Some(1_000_000_000), Some(2_000_000_000)),
+                make_link(1, true, Some(500_000_000), Some(0)),
+            ],
+        }];
+        let curr = vec![NvLinkSnapshot {
+            gpu_index: 0,
+            gpu_name: "H100".to_string(),
+            link_count: 3,
+            link_gbps: Some(150.0),
+            links: vec![
+                make_link(0, true, Some(1_500_000_000), Some(2_500_000_000)),
+                make_link(1, true, Some(700_000_000), Some(100_000_000)),
+                make_link(2, false, None, None),
+            ],
+        }];
+
+        let rows = compute_nvlink_throughputs(&prev, &curr, elapsed);
+        assert_eq!(rows.len(), 1);
+
+        let row = &rows[0];
+        assert_eq!(row.dev_name, "nvidia0");
+        assert_eq!(row.port, 2, "port column = active link count");
+        assert_eq!(row.port_label.as_deref(), Some("2/3"));
+        assert_eq!(row.link_gbps, Some(150.0));
+        assert_eq!(row.tx_pkts_per_sec, 0.0);
+        assert_eq!(row.rx_pkts_per_sec, 0.0);
+        assert_eq!(row.rx_drops_per_sec, 0.0);
+
+        // NVML exposes a *GPU-wide* aggregate for TX/RX, so the aggregate is
+        // the delta of the first active link only — NOT summed across links.
+        // tx delta: (1.5e9 - 1.0e9) = 0.5e9 bytes/sec
+        let expected_tx_gbps = 500_000_000.0_f64 * 8.0 / 1_000_000_000.0;
+        // rx delta: (2.5e9 - 2.0e9) = 0.5e9 bytes/sec
+        let expected_rx_gbps = 500_000_000.0_f64 * 8.0 / 1_000_000_000.0;
+        assert!(
+            (row.tx_gbps - expected_tx_gbps).abs() < 1e-6,
+            "tx_gbps {} != {}",
+            row.tx_gbps,
+            expected_tx_gbps
+        );
+        assert!(
+            (row.rx_gbps - expected_rx_gbps).abs() < 1e-6,
+            "rx_gbps {} != {}",
+            row.rx_gbps,
+            expected_rx_gbps
+        );
+
+        // Per-link *throughput* counter rates (nvlink_tx_lN / nvlink_rx_lN)
+        // are no longer emitted — the per-link counters in NVML are the same
+        // GPU-wide aggregate, so per-link rates would be redundant.
+        assert!(
+            !row.counter_rates
+                .iter()
+                .any(|c| c.name.starts_with("nvlink_tx_l")),
+            "per-link TX throughput counter rates must not be emitted"
+        );
+        assert!(
+            !row.counter_rates
+                .iter()
+                .any(|c| c.name.starts_with("nvlink_rx_l")),
+            "per-link RX throughput counter rates must not be emitted"
+        );
+
+        let nv = row.nvlink.as_ref().expect("nvlink meta present");
+        assert_eq!(nv.gpu_index, 0);
+        assert_eq!(nv.gpu_name, "H100");
+        assert_eq!(nv.active_links, 2);
+        assert_eq!(nv.links.len(), 3);
+    }
+
+    #[test]
+    fn aggregate_throughput_is_not_multiplied_by_active_link_count() {
+        // Two active links with identical TX/RX counters. NVML's per-link
+        // counters are actually a GPU-wide aggregate, so summing the deltas
+        // would double-count. The aggregate must reflect the single-link rate.
+        let elapsed = 1.0_f64;
+
+        let prev = vec![NvLinkSnapshot {
+            gpu_index: 0,
+            gpu_name: "H100".to_string(),
+            link_count: 2,
+            link_gbps: Some(100.0),
+            links: vec![
+                make_link(0, true, Some(1_000_000_000), Some(2_000_000_000)),
+                make_link(1, true, Some(1_000_000_000), Some(2_000_000_000)),
+            ],
+        }];
+        let curr = vec![NvLinkSnapshot {
+            gpu_index: 0,
+            gpu_name: "H100".to_string(),
+            link_count: 2,
+            link_gbps: Some(100.0),
+            links: vec![
+                make_link(0, true, Some(1_125_000_000), Some(2_125_000_000)),
+                make_link(1, true, Some(1_125_000_000), Some(2_125_000_000)),
+            ],
+        }];
+
+        let rows = compute_nvlink_throughputs(&prev, &curr, elapsed);
+        assert_eq!(rows.len(), 1);
+        let row = &rows[0];
+
+        // Single-link delta: tx = 0.125e9 bytes/sec, rx = 0.125e9 bytes/sec.
+        let expected_tx_gbps = 125_000_000.0_f64 * 8.0 / 1_000_000_000.0;
+        let expected_rx_gbps = 125_000_000.0_f64 * 8.0 / 1_000_000_000.0;
+        assert!(
+            (row.tx_gbps - expected_tx_gbps).abs() < 1e-6,
+            "tx_gbps {} != single-link rate {}",
+            row.tx_gbps,
+            expected_tx_gbps
+        );
+        assert!(
+            (row.rx_gbps - expected_rx_gbps).abs() < 1e-6,
+            "rx_gbps {} != single-link rate {}",
+            row.rx_gbps,
+            expected_rx_gbps
+        );
+        // If the bug regresses the aggregate would be 2x.
+        assert!(
+            row.tx_gbps < expected_tx_gbps * 1.5,
+            "tx_gbps {} unexpectedly large; sum-across-links bug?",
+            row.tx_gbps
+        );
+        assert!(
+            row.rx_gbps < expected_rx_gbps * 1.5,
+            "rx_gbps {} unexpectedly large; sum-across-links bug?",
+            row.rx_gbps
+        );
+        // Active-link count must still be reported for the port column.
+        assert_eq!(row.port, 2);
+        assert_eq!(row.port_label.as_deref(), Some("2/2"));
+    }
+
+    #[test]
+    fn aggregate_falls_back_to_first_link_when_no_active() {
+        // With no active links, NVML may still report non-zero byte counters
+        // on the (inactive) ports. We must pick one source for the aggregate;
+        // falling back to the first link (in list order) avoids dropping
+        // signal entirely when a GPU momentarily has no active links.
+        let elapsed = 1.0_f64;
+
+        let prev = vec![NvLinkSnapshot {
+            gpu_index: 0,
+            gpu_name: "H100".to_string(),
+            link_count: 2,
+            link_gbps: Some(100.0),
+            links: vec![
+                make_link(0, false, Some(0), Some(0)),
+                make_link(1, false, Some(0), Some(0)),
+            ],
+        }];
+        let curr = vec![NvLinkSnapshot {
+            gpu_index: 0,
+            gpu_name: "H100".to_string(),
+            link_count: 2,
+            link_gbps: Some(100.0),
+            links: vec![
+                make_link(0, false, Some(250_000_000), Some(125_000_000)),
+                make_link(1, false, Some(999_999_999), Some(999_999_999)),
+            ],
+        }];
+
+        let rows = compute_nvlink_throughputs(&prev, &curr, elapsed);
+        assert_eq!(rows.len(), 1);
+        let row = &rows[0];
+
+        // First link's delta wins.
+        let expected_tx_gbps = 250_000_000.0_f64 * 8.0 / 1_000_000_000.0;
+        let expected_rx_gbps = 125_000_000.0_f64 * 8.0 / 1_000_000_000.0;
+        assert!((row.tx_gbps - expected_tx_gbps).abs() < 1e-6);
+        assert!((row.rx_gbps - expected_rx_gbps).abs() < 1e-6);
+        assert_eq!(row.port, 0);
+        assert_eq!(row.port_label.as_deref(), Some("0/2"));
+    }
+
+    #[test]
+    fn missing_prev_snapshot_treats_curr_as_delta() {
+        let elapsed = 2.0_f64;
+        let curr = vec![NvLinkSnapshot {
+            gpu_index: 1,
+            gpu_name: "A100".to_string(),
+            link_count: 1,
+            link_gbps: Some(50.0),
+            links: vec![make_link(0, true, Some(2_000_000_000), Some(1_000_000_000))],
+        }];
+
+        let rows = compute_nvlink_throughputs(&[], &curr, elapsed);
+        assert_eq!(rows.len(), 1);
+        let row = &rows[0];
+        assert_eq!(row.dev_name, "nvidia1");
+        assert_eq!(row.port_label.as_deref(), Some("1/1"));
+        let expected_tx = 2_000_000_000.0_f64 * 8.0 / 1_000_000_000.0 / elapsed;
+        let expected_rx = 1_000_000_000.0_f64 * 8.0 / 1_000_000_000.0 / elapsed;
+        assert!((row.tx_gbps - expected_tx).abs() < 1e-6);
+        assert!((row.rx_gbps - expected_rx).abs() < 1e-6);
+    }
+
+    #[test]
+    fn rolling_avg_keeps_history_across_active_link_changes() {
+        // Build a single GPU NVLink snapshot with two active links.
+        let elapsed = 1.0_f64;
+        let links_first = vec![
+            make_link(0, true, Some(1_000_000_000), Some(2_000_000_000)),
+            make_link(1, true, Some(500_000_000), Some(250_000_000)),
+        ];
+        let prev = vec![NvLinkSnapshot {
+            gpu_index: 0,
+            gpu_name: "H100".to_string(),
+            link_count: 2,
+            link_gbps: Some(100.0),
+            links: links_first.clone(),
+        }];
+        let curr_first = vec![NvLinkSnapshot {
+            gpu_index: 0,
+            gpu_name: "H100".to_string(),
+            link_count: 3,
+            link_gbps: Some(150.0),
+            links: vec![
+                make_link(0, true, Some(1_500_000_000), Some(2_500_000_000)),
+                make_link(1, true, Some(700_000_000), Some(350_000_000)),
+                make_link(2, false, None, None),
+            ],
+        }];
+        let rows_first = compute_nvlink_throughputs(&prev, &curr_first, elapsed);
+        assert_eq!(rows_first.len(), 1);
+        assert_eq!(rows_first[0].port_label.as_deref(), Some("2/3"));
+
+        let mut state = RollingAvgState::new(5);
+        state.push(&rows_first);
+        assert_eq!(state.samples.len(), 1);
+
+        // Same GPU, different active link count -> port_label changes
+        // from "2/3" to "3/3". The history entry must be reused, not
+        // dropped and re-created.
+        let curr_second = vec![NvLinkSnapshot {
+            gpu_index: 0,
+            gpu_name: "H100".to_string(),
+            link_count: 3,
+            link_gbps: Some(150.0),
+            links: vec![
+                make_link(0, true, Some(2_000_000_000), Some(3_000_000_000)),
+                make_link(1, true, Some(900_000_000), Some(450_000_000)),
+                make_link(2, true, Some(100_000_000), Some(50_000_000)),
+            ],
+        }];
+        let rows_second = compute_nvlink_throughputs(&curr_first, &curr_second, elapsed);
+        assert_eq!(rows_second.len(), 1);
+        assert_eq!(rows_second[0].port_label.as_deref(), Some("3/3"));
+
+        state.push(&rows_second);
+
+        // Still exactly one history entry: the key is stable.
+        assert_eq!(
+            state.samples.len(),
+            1,
+            "expected stable key for NVLink rows across active-link changes"
+        );
+        // Buffer should hold two samples (the two pushes).
+        let buf = state
+            .samples
+            .values()
+            .next()
+            .expect("history entry for nvidia0");
+        assert_eq!(buf.len(), 2);
+        assert_eq!(buf[0].port_label.as_deref(), Some("2/3"));
+        assert_eq!(buf[1].port_label.as_deref(), Some("3/3"));
+    }
+
+    #[test]
+    fn rolling_avg_returns_averaged_nvlink_row() {
+        let elapsed = 1.0_f64;
+        let prev = vec![NvLinkSnapshot {
+            gpu_index: 0,
+            gpu_name: "H100".to_string(),
+            link_count: 1,
+            link_gbps: Some(50.0),
+            links: vec![make_link(0, true, Some(0), Some(0))],
+        }];
+        let curr = vec![NvLinkSnapshot {
+            gpu_index: 0,
+            gpu_name: "H100".to_string(),
+            link_count: 1,
+            link_gbps: Some(50.0),
+            links: vec![make_link(0, true, Some(1_000_000_000), Some(500_000_000))],
+        }];
+
+        let rows = compute_nvlink_throughputs(&prev, &curr, elapsed);
+        assert_eq!(rows.len(), 1);
+
+        let mut state = RollingAvgState::new(5);
+        state.push(&rows);
+
+        let avgs = state.averages();
+        assert_eq!(avgs.len(), 1);
+        let avg = &avgs[0];
+        assert_eq!(avg.dev_name, "nvidia0");
+        assert!(
+            avg.tx_gbps > 0.0,
+            "expected non-empty averaged tx_gbps, got {}",
+            avg.tx_gbps
+        );
+        let expected_tx = 1_000_000_000.0_f64 * 8.0 / 1_000_000_000.0;
+        assert!(
+            (avg.tx_gbps - expected_tx).abs() < 1e-6,
+            "tx_gbps {} != {}",
+            avg.tx_gbps,
+            expected_tx
+        );
+    }
+
+    #[test]
+    fn saturating_sub_protects_against_counter_resets() {
+        // Simulate NVML reloading the counters: prev is higher than curr.
+        let elapsed = 1.0_f64;
+        let prev = vec![NvLinkSnapshot {
+            gpu_index: 2,
+            gpu_name: "B200".to_string(),
+            link_count: 1,
+            link_gbps: Some(100.0),
+            links: vec![make_link(
+                0,
+                true,
+                Some(10_000_000_000),
+                Some(20_000_000_000),
+            )],
+        }];
+        let curr = vec![NvLinkSnapshot {
+            gpu_index: 2,
+            gpu_name: "B200".to_string(),
+            link_count: 1,
+            link_gbps: Some(100.0),
+            links: vec![make_link(0, true, Some(1_000), Some(2_000))],
+        }];
+
+        let rows = compute_nvlink_throughputs(&prev, &curr, elapsed);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(
+            rows[0].tx_gbps, 0.0,
+            "counter reset must not produce negative rate"
+        );
+        assert_eq!(rows[0].rx_gbps, 0.0);
+    }
+
+    #[test]
+    fn averaged_row_uses_latest_metadata() {
+        // Same GPU, two consecutive snapshots with different active-link
+        // counts (and therefore different `port` and `port_label`). The
+        // averaged row must reflect the *latest* metadata, not the oldest.
+        let elapsed = 1.0_f64;
+
+        let prev_a = vec![NvLinkSnapshot {
+            gpu_index: 0,
+            gpu_name: "H100".to_string(),
+            link_count: 3,
+            link_gbps: Some(150.0),
+            links: vec![make_link(0, true, Some(0), Some(0))],
+        }];
+        let curr_a = vec![NvLinkSnapshot {
+            gpu_index: 0,
+            gpu_name: "H100".to_string(),
+            link_count: 3,
+            link_gbps: Some(150.0),
+            links: vec![
+                make_link(0, true, Some(1_000_000_000), Some(2_000_000_000)),
+                make_link(1, true, Some(500_000_000), Some(250_000_000)),
+                make_link(2, false, None, None),
+            ],
+        }];
+        let rows_first = compute_nvlink_throughputs(&prev_a, &curr_a, elapsed);
+        assert_eq!(rows_first.len(), 1);
+        assert_eq!(rows_first[0].port_label.as_deref(), Some("2/3"));
+        assert_eq!(rows_first[0].port, 2);
+
+        // Second push: active link count rises to 3/3.
+        let curr_b = vec![NvLinkSnapshot {
+            gpu_index: 0,
+            gpu_name: "H100".to_string(),
+            link_count: 3,
+            link_gbps: Some(150.0),
+            links: vec![
+                make_link(0, true, Some(2_000_000_000), Some(3_000_000_000)),
+                make_link(1, true, Some(900_000_000), Some(450_000_000)),
+                make_link(2, true, Some(100_000_000), Some(50_000_000)),
+            ],
+        }];
+        let rows_second = compute_nvlink_throughputs(&curr_a, &curr_b, elapsed);
+        assert_eq!(rows_second.len(), 1);
+        assert_eq!(rows_second[0].port_label.as_deref(), Some("3/3"));
+        assert_eq!(rows_second[0].port, 3);
+
+        let mut state = RollingAvgState::new(5);
+        state.push(&rows_first);
+        state.push(&rows_second);
+
+        let avgs = state.averages();
+        assert_eq!(avgs.len(), 1);
+        let avg = &avgs[0];
+        // Metadata must come from the latest sample, not the oldest.
+        assert_eq!(
+            avg.port_label.as_deref(),
+            Some("3/3"),
+            "averaged row must use latest sample's port_label"
+        );
+        assert_eq!(avg.port, 3, "averaged row must use latest sample's port");
+        assert_eq!(avg.link_gbps, Some(150.0));
+        assert_eq!(avg.dev_name, "nvidia0");
+    }
+
+    #[test]
+    fn sort_order_stable_for_nvlink() {
+        // Reference ordering: RDMA "mlx5_0/1", NVLink "nvidia0" (active=2),
+        // RDMA "mlx5_1/1". The NVLink row sits in the middle.
+        let nvlink_ref = PortThroughput {
+            dev_name: "nvidia0".to_string(),
+            port: 2,
+            link_gbps: Some(150.0),
+            tx_gbps: 1.0,
+            rx_gbps: 2.0,
+            tx_pkts_per_sec: 0.0,
+            rx_pkts_per_sec: 0.0,
+            rx_drops_per_sec: 0.0,
+            counter_rates: Vec::new(),
+            port_label: Some("2/3".to_string()),
+            nvlink: Some(NvLinkThroughputMeta {
+                gpu_index: 0,
+                gpu_name: "H100".to_string(),
+                active_links: 2,
+                links: Vec::new(),
+            }),
+        };
+        let rdma_a_ref = PortThroughput {
+            dev_name: "mlx5_0".to_string(),
+            port: 1,
+            link_gbps: Some(100.0),
+            tx_gbps: 3.0,
+            rx_gbps: 4.0,
+            tx_pkts_per_sec: 0.0,
+            rx_pkts_per_sec: 0.0,
+            rx_drops_per_sec: 0.0,
+            counter_rates: Vec::new(),
+            port_label: None,
+            #[cfg(feature = "nvlink")]
+            nvlink: None,
+        };
+        let rdma_b_ref = PortThroughput {
+            dev_name: "mlx5_1".to_string(),
+            port: 1,
+            link_gbps: Some(100.0),
+            tx_gbps: 5.0,
+            rx_gbps: 6.0,
+            tx_pkts_per_sec: 0.0,
+            rx_pkts_per_sec: 0.0,
+            rx_drops_per_sec: 0.0,
+            counter_rates: Vec::new(),
+            port_label: None,
+            #[cfg(feature = "nvlink")]
+            nvlink: None,
+        };
+        let reference = vec![rdma_a_ref.clone(), nvlink_ref.clone(), rdma_b_ref.clone()];
+        let nvlink_ref_pos = 1usize;
+
+        // Build the averaged rows in shuffled order. Note the NVLink row now
+        // has `port: 3` (active-link count changed) and `port_label: "3/3"`.
+        let nvlink_avg = PortThroughput {
+            dev_name: "nvidia0".to_string(),
+            port: 3,
+            link_gbps: Some(150.0),
+            tx_gbps: 1.5,
+            rx_gbps: 2.5,
+            tx_pkts_per_sec: 0.0,
+            rx_pkts_per_sec: 0.0,
+            rx_drops_per_sec: 0.0,
+            counter_rates: Vec::new(),
+            port_label: Some("3/3".to_string()),
+            #[cfg(feature = "nvlink")]
+            nvlink: Some(NvLinkThroughputMeta {
+                gpu_index: 0,
+                gpu_name: "H100".to_string(),
+                active_links: 3,
+                links: Vec::new(),
+            }),
+        };
+        let rdma_a_avg = PortThroughput {
+            dev_name: "mlx5_0".to_string(),
+            port: 1,
+            link_gbps: Some(100.0),
+            tx_gbps: 3.5,
+            rx_gbps: 4.5,
+            tx_pkts_per_sec: 0.0,
+            rx_pkts_per_sec: 0.0,
+            rx_drops_per_sec: 0.0,
+            counter_rates: Vec::new(),
+            port_label: None,
+            #[cfg(feature = "nvlink")]
+            nvlink: None,
+        };
+        let rdma_b_avg = PortThroughput {
+            dev_name: "mlx5_1".to_string(),
+            port: 1,
+            link_gbps: Some(100.0),
+            tx_gbps: 5.5,
+            rx_gbps: 6.5,
+            tx_pkts_per_sec: 0.0,
+            rx_pkts_per_sec: 0.0,
+            rx_drops_per_sec: 0.0,
+            counter_rates: Vec::new(),
+            port_label: None,
+            #[cfg(feature = "nvlink")]
+            nvlink: None,
+        };
+        let mut avgs = vec![rdma_b_avg.clone(), nvlink_avg.clone(), rdma_a_avg.clone()];
+
+        sort_by_throughput_order(&mut avgs, &reference);
+
+        // After sorting the averaged list must mirror the reference order:
+        // mlx5_0, nvidia0, mlx5_1.
+        assert_eq!(avgs[0].dev_name, "mlx5_0");
+        assert_eq!(avgs[1].dev_name, "nvidia0");
+        assert_eq!(avgs[2].dev_name, "mlx5_1");
+        // The NVLink row must NOT have been pushed to the end via
+        // `unwrap_or(&usize::MAX)` (which would happen if the sort key still
+        // included the changed `port` field).
+        assert_eq!(avgs[1].dev_name, nvlink_ref.dev_name);
+        assert_ne!(avgs[1].port, nvlink_ref.port);
+        assert_eq!(avgs[1].port_label, nvlink_avg.port_label);
+        // Sanity: the NVLink row's resolved index in the reference equals the
+        // original reference position, confirming the key match.
+        let _ = nvlink_ref_pos;
+    }
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -923,30 +923,58 @@ fn compute_nvlink_throughputs(
         let prev_gpu = prev.iter().find(|p| p.gpu_index == gpu.gpu_index);
         let mut counter_rates: Vec<CounterRate> = Vec::new();
 
-        // Pick a single link to source the GPU-wide TX/RX aggregate from.
-        // Prefer the first active link; if none are active, fall back to the
-        // first link in the list (its counters still represent the GPU).
-        let aggregate_link = gpu
-            .links
-            .iter()
-            .find(|l| l.is_active)
-            .or_else(|| gpu.links.first());
-
-        let (tx_bytes_total, rx_bytes_total) = match aggregate_link {
-            Some(link) => {
-                let prev_link =
-                    prev_gpu.and_then(|p| p.links.iter().find(|l| l.link_id == link.link_id));
-                let curr_tx = link.tx_bytes.unwrap_or(0);
-                let prev_tx = prev_link.and_then(|l| l.tx_bytes).unwrap_or(0);
-                let curr_rx = link.rx_bytes.unwrap_or(0);
-                let prev_rx = prev_link.and_then(|l| l.rx_bytes).unwrap_or(0);
-                (
-                    curr_tx.saturating_sub(prev_tx),
-                    curr_rx.saturating_sub(prev_rx),
-                )
+        // Calculate GPU-wide aggregate throughput, preferring the u32::MAX aggregate fields.
+        let (tx_bytes_total, rx_bytes_total) = if gpu.tx_bytes.is_some() || gpu.rx_bytes.is_some() {
+            let curr_tx = gpu.tx_bytes.unwrap_or(0);
+            let prev_tx = prev_gpu.and_then(|p| p.tx_bytes).unwrap_or(0);
+            let curr_rx = gpu.rx_bytes.unwrap_or(0);
+            let prev_rx = prev_gpu.and_then(|p| p.rx_bytes).unwrap_or(0);
+            (
+                curr_tx.saturating_sub(prev_tx),
+                curr_rx.saturating_sub(prev_rx),
+            )
+        } else {
+            // Fallback: Pick a single link to source the GPU-wide TX/RX aggregate from.
+            let aggregate_link = gpu
+                .links
+                .iter()
+                .find(|l| l.is_active)
+                .or_else(|| gpu.links.first());
+            match aggregate_link {
+                Some(link) => {
+                    let prev_link =
+                        prev_gpu.and_then(|p| p.links.iter().find(|l| l.link_id == link.link_id));
+                    let curr_tx = link.tx_bytes.unwrap_or(0);
+                    let prev_tx = prev_link.and_then(|l| l.tx_bytes).unwrap_or(0);
+                    let curr_rx = link.rx_bytes.unwrap_or(0);
+                    let prev_rx = prev_link.and_then(|l| l.rx_bytes).unwrap_or(0);
+                    (
+                        curr_tx.saturating_sub(prev_tx),
+                        curr_rx.saturating_sub(prev_rx),
+                    )
+                }
+                None => (0, 0),
             }
-            None => (0, 0),
         };
+
+        // Compute individual link rates in bytes per second to store in the metadata links
+        let mut links = Vec::with_capacity(gpu.links.len());
+        for link in &gpu.links {
+            let prev_link =
+                prev_gpu.and_then(|p| p.links.iter().find(|l| l.link_id == link.link_id));
+            let curr_tx = link.tx_bytes.unwrap_or(0);
+            let prev_tx = prev_link.and_then(|l| l.tx_bytes).unwrap_or(0);
+            let curr_rx = link.rx_bytes.unwrap_or(0);
+            let prev_rx = prev_link.and_then(|l| l.rx_bytes).unwrap_or(0);
+
+            let rate_tx = (curr_tx.saturating_sub(prev_tx) as f64 / elapsed) as u64;
+            let rate_rx = (curr_rx.saturating_sub(prev_rx) as f64 / elapsed) as u64;
+
+            let mut link_clone = link.clone();
+            link_clone.tx_bytes = Some(rate_tx);
+            link_clone.rx_bytes = Some(rate_rx);
+            links.push(link_clone);
+        }
 
         for link in &gpu.links {
             let prev_link =
@@ -1003,7 +1031,7 @@ fn compute_nvlink_throughputs(
                 gpu_index: gpu.gpu_index,
                 gpu_name: gpu.gpu_name.clone(),
                 active_links: active,
-                links: gpu.links.clone(),
+                links,
             }),
         });
     }
@@ -1040,6 +1068,8 @@ mod nvlink_tests {
             gpu_name: "H100".to_string(),
             link_count: 2,
             link_gbps: Some(100.0),
+            tx_bytes: None,
+            rx_bytes: None,
             links: vec![
                 make_link(0, true, Some(1_000_000_000), Some(2_000_000_000)),
                 make_link(1, true, Some(500_000_000), Some(0)),
@@ -1050,6 +1080,8 @@ mod nvlink_tests {
             gpu_name: "H100".to_string(),
             link_count: 3,
             link_gbps: Some(150.0),
+            tx_bytes: None,
+            rx_bytes: None,
             links: vec![
                 make_link(0, true, Some(1_500_000_000), Some(2_500_000_000)),
                 make_link(1, true, Some(700_000_000), Some(100_000_000)),
@@ -1123,6 +1155,8 @@ mod nvlink_tests {
             gpu_name: "H100".to_string(),
             link_count: 2,
             link_gbps: Some(100.0),
+            tx_bytes: None,
+            rx_bytes: None,
             links: vec![
                 make_link(0, true, Some(1_000_000_000), Some(2_000_000_000)),
                 make_link(1, true, Some(1_000_000_000), Some(2_000_000_000)),
@@ -1133,6 +1167,8 @@ mod nvlink_tests {
             gpu_name: "H100".to_string(),
             link_count: 2,
             link_gbps: Some(100.0),
+            tx_bytes: None,
+            rx_bytes: None,
             links: vec![
                 make_link(0, true, Some(1_125_000_000), Some(2_125_000_000)),
                 make_link(1, true, Some(1_125_000_000), Some(2_125_000_000)),
@@ -1187,6 +1223,8 @@ mod nvlink_tests {
             gpu_name: "H100".to_string(),
             link_count: 2,
             link_gbps: Some(100.0),
+            tx_bytes: None,
+            rx_bytes: None,
             links: vec![
                 make_link(0, false, Some(0), Some(0)),
                 make_link(1, false, Some(0), Some(0)),
@@ -1197,6 +1235,8 @@ mod nvlink_tests {
             gpu_name: "H100".to_string(),
             link_count: 2,
             link_gbps: Some(100.0),
+            tx_bytes: None,
+            rx_bytes: None,
             links: vec![
                 make_link(0, false, Some(250_000_000), Some(125_000_000)),
                 make_link(1, false, Some(999_999_999), Some(999_999_999)),
@@ -1224,6 +1264,8 @@ mod nvlink_tests {
             gpu_name: "A100".to_string(),
             link_count: 1,
             link_gbps: Some(50.0),
+            tx_bytes: None,
+            rx_bytes: None,
             links: vec![make_link(0, true, Some(2_000_000_000), Some(1_000_000_000))],
         }];
 
@@ -1251,6 +1293,8 @@ mod nvlink_tests {
             gpu_name: "H100".to_string(),
             link_count: 2,
             link_gbps: Some(100.0),
+            tx_bytes: None,
+            rx_bytes: None,
             links: links_first.clone(),
         }];
         let curr_first = vec![NvLinkSnapshot {
@@ -1258,6 +1302,8 @@ mod nvlink_tests {
             gpu_name: "H100".to_string(),
             link_count: 3,
             link_gbps: Some(150.0),
+            tx_bytes: None,
+            rx_bytes: None,
             links: vec![
                 make_link(0, true, Some(1_500_000_000), Some(2_500_000_000)),
                 make_link(1, true, Some(700_000_000), Some(350_000_000)),
@@ -1280,6 +1326,8 @@ mod nvlink_tests {
             gpu_name: "H100".to_string(),
             link_count: 3,
             link_gbps: Some(150.0),
+            tx_bytes: None,
+            rx_bytes: None,
             links: vec![
                 make_link(0, true, Some(2_000_000_000), Some(3_000_000_000)),
                 make_link(1, true, Some(900_000_000), Some(450_000_000)),
@@ -1317,6 +1365,8 @@ mod nvlink_tests {
             gpu_name: "H100".to_string(),
             link_count: 1,
             link_gbps: Some(50.0),
+            tx_bytes: None,
+            rx_bytes: None,
             links: vec![make_link(0, true, Some(0), Some(0))],
         }];
         let curr = vec![NvLinkSnapshot {
@@ -1324,6 +1374,8 @@ mod nvlink_tests {
             gpu_name: "H100".to_string(),
             link_count: 1,
             link_gbps: Some(50.0),
+            tx_bytes: None,
+            rx_bytes: None,
             links: vec![make_link(0, true, Some(1_000_000_000), Some(500_000_000))],
         }];
 
@@ -1360,6 +1412,8 @@ mod nvlink_tests {
             gpu_name: "B200".to_string(),
             link_count: 1,
             link_gbps: Some(100.0),
+            tx_bytes: None,
+            rx_bytes: None,
             links: vec![make_link(
                 0,
                 true,
@@ -1372,6 +1426,8 @@ mod nvlink_tests {
             gpu_name: "B200".to_string(),
             link_count: 1,
             link_gbps: Some(100.0),
+            tx_bytes: None,
+            rx_bytes: None,
             links: vec![make_link(0, true, Some(1_000), Some(2_000))],
         }];
 
@@ -1396,6 +1452,8 @@ mod nvlink_tests {
             gpu_name: "H100".to_string(),
             link_count: 3,
             link_gbps: Some(150.0),
+            tx_bytes: None,
+            rx_bytes: None,
             links: vec![make_link(0, true, Some(0), Some(0))],
         }];
         let curr_a = vec![NvLinkSnapshot {
@@ -1403,6 +1461,8 @@ mod nvlink_tests {
             gpu_name: "H100".to_string(),
             link_count: 3,
             link_gbps: Some(150.0),
+            tx_bytes: None,
+            rx_bytes: None,
             links: vec![
                 make_link(0, true, Some(1_000_000_000), Some(2_000_000_000)),
                 make_link(1, true, Some(500_000_000), Some(250_000_000)),
@@ -1420,6 +1480,8 @@ mod nvlink_tests {
             gpu_name: "H100".to_string(),
             link_count: 3,
             link_gbps: Some(150.0),
+            tx_bytes: None,
+            rx_bytes: None,
             links: vec![
                 make_link(0, true, Some(2_000_000_000), Some(3_000_000_000)),
                 make_link(1, true, Some(900_000_000), Some(450_000_000)),
@@ -1447,6 +1509,57 @@ mod nvlink_tests {
         assert_eq!(avg.port, 3, "averaged row must use latest sample's port");
         assert_eq!(avg.link_gbps, Some(150.0));
         assert_eq!(avg.dev_name, "nvidia0");
+    }
+
+    #[test]
+    fn aggregates_uses_gpu_wide_fields_when_present() {
+        let elapsed = 1.0_f64;
+
+        let prev = vec![NvLinkSnapshot {
+            gpu_index: 0,
+            gpu_name: "H100".to_string(),
+            link_count: 2,
+            link_gbps: Some(100.0),
+            tx_bytes: Some(10_000_000_000),
+            rx_bytes: Some(20_000_000_000),
+            links: vec![
+                make_link(0, true, Some(0), Some(0)),
+                make_link(1, true, Some(0), Some(0)),
+            ],
+        }];
+        let curr = vec![NvLinkSnapshot {
+            gpu_index: 0,
+            gpu_name: "H100".to_string(),
+            link_count: 2,
+            link_gbps: Some(100.0),
+            tx_bytes: Some(15_000_000_000),
+            rx_bytes: Some(25_000_000_000),
+            links: vec![
+                make_link(0, true, Some(100_000), Some(200_000)), // These are lane rates, shouldn't be used for aggregate
+                make_link(1, true, Some(300_000), Some(400_000)),
+            ],
+        }];
+
+        let rows = compute_nvlink_throughputs(&prev, &curr, elapsed);
+        assert_eq!(rows.len(), 1);
+        let row = &rows[0];
+
+        // Aggregate should be:
+        // tx = 15e9 - 10e9 = 5e9 bytes/sec -> 40 Gbps
+        // rx = 25e9 - 20e9 = 5e9 bytes/sec -> 40 Gbps
+        let expected_tx_gbps = 5_000_000_000.0_f64 * 8.0 / 1_000_000_000.0;
+        let expected_rx_gbps = 5_000_000_000.0_f64 * 8.0 / 1_000_000_000.0;
+        assert!((row.tx_gbps - expected_tx_gbps).abs() < 1e-6);
+        assert!((row.rx_gbps - expected_rx_gbps).abs() < 1e-6);
+
+        // However, individual lanes should show the lane-specific rates (calculated from lane deltas):
+        // lane 0 tx: (100_000 - 0) / 1.0 = 100_000 bytes/sec
+        // lane 0 rx: (200_000 - 0) / 1.0 = 200_000 bytes/sec
+        let nv = row.nvlink.as_ref().unwrap();
+        assert_eq!(nv.links[0].tx_bytes, Some(100_000));
+        assert_eq!(nv.links[0].rx_bytes, Some(200_000));
+        assert_eq!(nv.links[1].tx_bytes, Some(300_000));
+        assert_eq!(nv.links[1].rx_bytes, Some(400_000));
     }
 
     #[test]

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -525,7 +525,7 @@ fn build_nvlink_detail_lines(
     // Muted note explaining that the per-lane TX/RX columns below show the
     // GPU-wide aggregate, since NVML does not expose per-lane throughput.
     lines.push(Line::from(styled(
-        " Per-lane throughput is not available from NVML; TX/RX values below are the GPU aggregate.",
+        " Per-lane throughput is not available from NVML on some drivers; values below show either per-lane rate or the GPU aggregate.",
         tc.muted,
         false,
     )));
@@ -537,12 +537,18 @@ fn build_nvlink_detail_lines(
         true,
     )]));
 
-    // One row per link (active + inactive). NVML does not expose per-lane
-    // throughput, so each lane row shows the same GPU-wide aggregate rate
-    // (converted from Gbps to MB/s via Gbps * 1000 / 8).
-    let tx_mb_s = t.tx_gbps * 1000.0 / 8.0;
-    let rx_mb_s = t.rx_gbps * 1000.0 / 8.0;
+    // One row per link (active + inactive). Render per-lane throughput if available,
+    // otherwise fallback to the GPU aggregate rate (converted from Gbps to MB/s).
     for link in &meta.links {
+        let link_tx_mb_s = match link.tx_bytes {
+            Some(bytes) => bytes as f64 / 1_000_000.0,
+            None => t.tx_gbps * 1000.0 / 8.0,
+        };
+        let link_rx_mb_s = match link.rx_bytes {
+            Some(bytes) => bytes as f64 / 1_000_000.0,
+            None => t.rx_gbps * 1000.0 / 8.0,
+        };
+
         let state_label = if link.is_active {
             "enabled"
         } else {
@@ -564,8 +570,8 @@ fn build_nvlink_detail_lines(
             styled(&format!(" {:>4}", link.link_id), tc.accent, false),
             styled(&format!("  {:<8}", state_label), state_color, false),
             styled(&format!("  {:>3}", ver_label), tc.fg, false),
-            styled(&format!("  {:>6.1}", tx_mb_s), tc.fg, false),
-            styled(&format!("  {:>6.1}", rx_mb_s), tc.fg, false),
+            styled(&format!("  {:>6.1}", link_tx_mb_s), tc.fg, false),
+            styled(&format!("  {:>6.1}", link_rx_mb_s), tc.fg, false),
             styled(&format!("  {}", remote_label), tc.muted, false),
         ]));
     }
@@ -1470,5 +1476,75 @@ mod nvlink_detail_tests {
             occurrences, 3,
             "expected the aggregate MB/s value in 3 lane rows, got {occurrences}"
         );
+    }
+
+    #[test]
+    fn lanes_show_per_lane_rates_when_present() {
+        let links = vec![
+            make_link(
+                0,
+                true,
+                RemoteDeviceType::Switch,
+                Some("0000:01:00.0"),
+                Some(10_000_000), // 10 MB/s
+                Some(20_000_000), // 20 MB/s
+                None,
+                None,
+                None,
+                Some(3),
+            ),
+            make_link(
+                1,
+                true,
+                RemoteDeviceType::Gpu,
+                Some("0000:02:00.0"),
+                Some(30_000_000), // 30 MB/s
+                Some(40_000_000), // 40 MB/s
+                None,
+                None,
+                None,
+                Some(3),
+            ),
+        ];
+        let meta = NvLinkThroughputMeta {
+            gpu_index: 0,
+            gpu_name: "H100".to_string(),
+            active_links: 2,
+            links: links.clone(),
+        };
+        let port = PortThroughput {
+            dev_name: "nvidia0".to_string(),
+            port: 2,
+            link_gbps: Some(100.0),
+            tx_gbps: 1.0,
+            rx_gbps: 1.0,
+            tx_pkts_per_sec: 0.0,
+            rx_pkts_per_sec: 0.0,
+            rx_drops_per_sec: 0.0,
+            counter_rates: Vec::new(),
+            port_label: Some("2/2".to_string()),
+            nvlink: Some(meta.clone()),
+        };
+
+        let tc = Theme::Default.colors();
+        let lines = build_nvlink_detail_lines(&port, &meta, None, &tc, false, 0);
+
+        // lane 0 row should contain "  10.0" and "  20.0"
+        let lane0_row = lines
+            .iter()
+            .find(|l| l.to_string().starts_with("    0 "))
+            .unwrap()
+            .to_string();
+        assert!(lane0_row.contains("  10.0"), "lane 0 missing TX: {lane0_row:?}");
+        assert!(lane0_row.contains("  20.0"), "lane 0 missing RX: {lane0_row:?}");
+
+        // lane 1 row should contain "  30.0" and "  40.0"
+        let lane1_row = lines
+            .iter()
+            .find(|l| l.to_string().starts_with("    1 "))
+            .unwrap()
+            .to_string();
+        assert!(lane1_row.contains("  30.0"), "lane 1 missing TX: {lane1_row:?}");
+        assert!(lane1_row.contains("  40.0"), "lane 1 missing RX: {lane1_row:?}");
     }
 }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -230,7 +230,10 @@ fn gbps_bar(gbps: f64, link_gbps: Option<f64>) -> String {
 fn column_cell(col: &TableColumn, t: &PortThroughput, tc: &ThemeColors) -> Cell<'static> {
     match col {
         TableColumn::Device => Cell::from(t.dev_name.clone()).style(Style::default().fg(tc.fg)),
-        TableColumn::Port => Cell::from(t.port.to_string()).style(Style::default().fg(tc.muted)),
+        TableColumn::Port => {
+            let port_text = t.port_label.clone().unwrap_or_else(|| t.port.to_string());
+            Cell::from(port_text).style(Style::default().fg(tc.muted))
+        }
         TableColumn::TxBar => Cell::from(gbps_bar(t.tx_gbps, t.link_gbps))
             .style(Style::default().fg(gbps_color(t.tx_gbps, tc))),
         TableColumn::TxGbps => Cell::from(format!("{:.2}", t.tx_gbps))
@@ -460,6 +463,136 @@ fn build_detail_lines(
     lines
 }
 
+/// Build the per-lane detail panel for a NVLink GPU row.
+///
+/// Layout:
+///   Device: nvidiaN  [NVLink]  active/total active
+///   TX/RX aggregate Gbps with sparkline
+///   Lane table header (Lane, State, Ver, TX MB/s, RX MB/s, Remote)
+///   One row per link, including inactive lanes
+///   Summed error counters (replay/recovery/crc)
+#[cfg(feature = "nvlink")]
+fn build_nvlink_detail_lines(
+    t: &PortThroughput,
+    meta: &super::app::NvLinkThroughputMeta,
+    history: Option<&super::app::DeviceHistory>,
+    tc: &ThemeColors,
+    show_avg: bool,
+    avg_window: usize,
+) -> Vec<Line<'static>> {
+    let spark_w = 30;
+    let (tx_spark, rx_spark) = match history {
+        Some(h) => (sparkline_str(&h.tx, spark_w), sparkline_str(&h.rx, spark_w)),
+        None => (" ".repeat(spark_w), " ".repeat(spark_w)),
+    };
+    let avg_label = if show_avg {
+        format!("  [avg {}s]", avg_window)
+    } else {
+        String::new()
+    };
+
+    let mut lines: Vec<Line<'static>> = Vec::new();
+
+    // Header: Device: nvidiaN  [NVLink]  active/total active
+    lines.push(Line::from(vec![
+        styled(" Device: ", tc.muted, false),
+        styled(&t.dev_name, tc.accent, true),
+        styled("  [NVLink]  ", tc.accent, false),
+        styled(
+            &format!("{}/{} active", meta.active_links, meta.links.len()),
+            tc.fg,
+            false,
+        ),
+        styled(&avg_label, tc.accent, false),
+    ]));
+
+    // Aggregate TX line with sparkline.
+    lines.push(Line::from(vec![
+        styled(" TX: ", tc.muted, false),
+        styled(&format!("{:.2} Gbps ", t.tx_gbps), tc.good, false),
+        styled(&tx_spark, tc.good, false),
+    ]));
+
+    // Aggregate RX line with sparkline.
+    lines.push(Line::from(vec![
+        styled(" RX: ", tc.muted, false),
+        styled(&format!("{:.2} Gbps ", t.rx_gbps), tc.accent, false),
+        styled(&rx_spark, tc.accent, false),
+    ]));
+
+    lines.push(Line::from(""));
+
+    // Muted note explaining that the per-lane TX/RX columns below show the
+    // GPU-wide aggregate, since NVML does not expose per-lane throughput.
+    lines.push(Line::from(styled(
+        " Per-lane throughput is not available from NVML; TX/RX values below are the GPU aggregate.",
+        tc.muted,
+        false,
+    )));
+
+    // Lane table header.
+    lines.push(Line::from(vec![styled(
+        " Lane  State     Ver   TX MB/s   RX MB/s  Remote",
+        tc.header_fg,
+        true,
+    )]));
+
+    // One row per link (active + inactive). NVML does not expose per-lane
+    // throughput, so each lane row shows the same GPU-wide aggregate rate
+    // (converted from Gbps to MB/s via Gbps * 1000 / 8).
+    let tx_mb_s = t.tx_gbps * 1000.0 / 8.0;
+    let rx_mb_s = t.rx_gbps * 1000.0 / 8.0;
+    for link in &meta.links {
+        let state_label = if link.is_active {
+            "enabled"
+        } else {
+            "disabled"
+        };
+        let state_color = if link.is_active { tc.good } else { tc.muted };
+        let ver_label = link
+            .version
+            .map(|v| v.to_string())
+            .unwrap_or_else(|| "-".to_string());
+        let remote_label = match (&link.remote_pci_bdf, &link.remote_device_type) {
+            (Some(bdf), ty) => format!("{} {}", ty.label(), bdf),
+            (None, ty) => match ty {
+                crate::nvlink::RemoteDeviceType::Unknown => "-".to_string(),
+                _ => ty.label().to_string(),
+            },
+        };
+        lines.push(Line::from(vec![
+            styled(&format!(" {:>4}", link.link_id), tc.accent, false),
+            styled(&format!("  {:<8}", state_label), state_color, false),
+            styled(&format!("  {:>3}", ver_label), tc.fg, false),
+            styled(&format!("  {:>6.1}", tx_mb_s), tc.fg, false),
+            styled(&format!("  {:>6.1}", rx_mb_s), tc.fg, false),
+            styled(&format!("  {}", remote_label), tc.muted, false),
+        ]));
+    }
+
+    lines.push(Line::from(""));
+
+    // Errors line: sum per-link counters across all lanes. None -> 0.
+    let mut crc: u64 = 0;
+    let mut replay: u64 = 0;
+    let mut recovery: u64 = 0;
+    for link in &meta.links {
+        crc = crc.saturating_add(link.crc_error_count.unwrap_or(0));
+        replay = replay.saturating_add(link.replay_error_count.unwrap_or(0));
+        recovery = recovery.saturating_add(link.recovery_error_count.unwrap_or(0));
+    }
+    lines.push(Line::from(vec![
+        styled(" Errors: ", tc.muted, false),
+        styled(&format!("replay={}", replay), tc.warning, false),
+        styled("  ", tc.muted, false),
+        styled(&format!("recovery={}", recovery), tc.warning, false),
+        styled("  ", tc.muted, false),
+        styled(&format!("crc={}", crc), tc.warning, false),
+    ]));
+
+    lines
+}
+
 fn build_device_header(
     t: &PortThroughput,
     history: Option<&super::app::DeviceHistory>,
@@ -584,6 +717,29 @@ fn draw_detail(frame: &mut Frame, app: &mut App, area: Rect, tc: &ThemeColors) {
 
     let history = app.history.get(&t.dev_name);
     let procs = app.selected_device_processes();
+
+    #[cfg(feature = "nvlink")]
+    let lines = if let Some(ref meta) = t.nvlink {
+        build_nvlink_detail_lines(
+            &t,
+            meta,
+            history,
+            tc,
+            app.show_rolling_avg,
+            app.rolling_avg.window_secs,
+        )
+    } else {
+        build_detail_lines(
+            &t,
+            &procs,
+            history,
+            tc,
+            app.show_rolling_avg,
+            app.rolling_avg.window_secs,
+        )
+    };
+
+    #[cfg(not(feature = "nvlink"))]
     let lines = build_detail_lines(
         &t,
         &procs,
@@ -878,5 +1034,441 @@ fn truncate(s: &str, max: usize) -> String {
         s.to_string()
     } else {
         format!("{}…", &s[..max - 1])
+    }
+}
+
+#[cfg(all(test, feature = "nvlink"))]
+mod nvlink_detail_tests {
+    use super::*;
+    use crate::nvlink::{LinkSnapshot, RemoteDeviceType};
+    use crate::tui::app::{CounterRate, NvLinkThroughputMeta};
+    use crate::tui::theme::Theme;
+
+    #[allow(clippy::too_many_arguments)]
+    fn make_link(
+        id: u32,
+        active: bool,
+        remote_type: RemoteDeviceType,
+        remote_bdf: Option<&str>,
+        tx_bytes: Option<u64>,
+        rx_bytes: Option<u64>,
+        crc: Option<u64>,
+        replay: Option<u64>,
+        recovery: Option<u64>,
+        version: Option<u32>,
+    ) -> LinkSnapshot {
+        LinkSnapshot {
+            link_id: id,
+            is_active: active,
+            version,
+            speed_gbps: if active { Some(50.0) } else { None },
+            remote_device_type: remote_type,
+            remote_pci_bdf: remote_bdf.map(|s| s.to_string()),
+            tx_bytes,
+            rx_bytes,
+            crc_error_count: crc,
+            replay_error_count: replay,
+            recovery_error_count: recovery,
+        }
+    }
+
+    /// Build a synthetic `PortThroughput` whose `counter_rates` contain one
+    /// `nvlink_tx_l<N>` / `nvlink_rx_l<N>` pair per provided link, with the
+    /// supplied `tx_rate` / `rx_rate` (bytes/sec) values. Returned tuple is
+    /// `(PortThroughput, NvLinkThroughputMeta)` — they share the same `links`
+    /// list so the detail renderer sees a consistent view.
+    fn make_port(
+        dev_name: &str,
+        links: Vec<LinkSnapshot>,
+        tx_rate_bps: f64,
+        rx_rate_bps: f64,
+    ) -> (PortThroughput, NvLinkThroughputMeta) {
+        let counter_rates: Vec<CounterRate> = links
+            .iter()
+            .flat_map(|l| {
+                vec![
+                    CounterRate {
+                        name: format!("nvlink_tx_l{}", l.link_id),
+                        value: l.tx_bytes.unwrap_or(0),
+                        delta: 0,
+                        rate: tx_rate_bps,
+                        is_bytes: true,
+                    },
+                    CounterRate {
+                        name: format!("nvlink_rx_l{}", l.link_id),
+                        value: l.rx_bytes.unwrap_or(0),
+                        delta: 0,
+                        rate: rx_rate_bps,
+                        is_bytes: true,
+                    },
+                ]
+            })
+            .collect();
+        let active = links.iter().filter(|l| l.is_active).count() as u32;
+        let meta = NvLinkThroughputMeta {
+            gpu_index: 0,
+            gpu_name: "H100".to_string(),
+            active_links: active,
+            links: links.clone(),
+        };
+        let port = PortThroughput {
+            dev_name: dev_name.to_string(),
+            port: active,
+            link_gbps: Some(50.0),
+            tx_gbps: 0.0,
+            rx_gbps: 0.0,
+            tx_pkts_per_sec: 0.0,
+            rx_pkts_per_sec: 0.0,
+            rx_drops_per_sec: 0.0,
+            counter_rates,
+            port_label: Some(format!("{}/{}", active, links.len())),
+            nvlink: Some(meta.clone()),
+        };
+        (port, meta)
+    }
+
+    fn join_lines(lines: &[Line<'static>]) -> String {
+        let mut s = String::new();
+        for line in lines {
+            s.push_str(&line.to_string());
+            s.push('\n');
+        }
+        s
+    }
+
+    #[test]
+    fn header_contains_device_and_active_count() {
+        let links = vec![
+            make_link(
+                0,
+                true,
+                RemoteDeviceType::Switch,
+                Some("0000:01:00.0"),
+                None,
+                None,
+                None,
+                None,
+                None,
+                Some(3),
+            ),
+            make_link(
+                1,
+                true,
+                RemoteDeviceType::Switch,
+                Some("0000:01:00.0"),
+                None,
+                None,
+                None,
+                None,
+                None,
+                Some(3),
+            ),
+            make_link(
+                2,
+                false,
+                RemoteDeviceType::Unknown,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            ),
+        ];
+        let (port, meta) = make_port("nvidia0", links, 0.0, 0.0);
+        let tc = Theme::Default.colors();
+        let lines = build_nvlink_detail_lines(&port, &meta, None, &tc, false, 0);
+        let header = lines[0].to_string();
+        assert!(
+            header.contains("Device: nvidia0"),
+            "header missing device label: {header:?}"
+        );
+        assert!(
+            header.contains("[NVLink]"),
+            "header missing NVLink tag: {header:?}"
+        );
+        assert!(
+            header.contains("2/3 active"),
+            "header missing active/total count: {header:?}"
+        );
+        // No avg label when show_avg=false.
+        assert!(
+            !header.contains("[avg"),
+            "avg label should be hidden: {header:?}"
+        );
+    }
+
+    #[test]
+    fn inactive_link_renders_disabled_and_dash_remote() {
+        let links = vec![make_link(
+            0,
+            false,
+            RemoteDeviceType::Unknown,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )];
+        let (port, meta) = make_port("nvidia0", links, 0.0, 0.0);
+        let tc = Theme::Default.colors();
+        let lines = build_nvlink_detail_lines(&port, &meta, None, &tc, false, 0);
+        let blob = join_lines(&lines);
+        assert!(blob.contains("disabled"), "missing 'disabled': {blob}");
+        // Remote label column for Unknown remote with no BDF should be "-".
+        // The row layout puts the remote label at the end; check it ends with "  -".
+        let lane_row = lines
+            .iter()
+            .find(|l| l.to_string().contains("disabled"))
+            .expect("lane row with disabled");
+        let s = lane_row.to_string();
+        assert!(
+            s.trim_end().ends_with('-'),
+            "inactive row should end with '-': {s:?}"
+        );
+    }
+
+    #[test]
+    fn active_link_renders_remote_pci_bdf() {
+        let links = vec![make_link(
+            2,
+            true,
+            RemoteDeviceType::Switch,
+            Some("0000:01:00.0"),
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(4),
+        )];
+        let (port, meta) = make_port("nvidia0", links, 0.0, 0.0);
+        let tc = Theme::Default.colors();
+        let lines = build_nvlink_detail_lines(&port, &meta, None, &tc, false, 0);
+        let blob = join_lines(&lines);
+        assert!(
+            blob.contains("NVSwitch 0000:01:00.0"),
+            "active switch link missing remote label: {blob}"
+        );
+        assert!(
+            blob.contains("enabled"),
+            "active link row should be 'enabled': {blob}"
+        );
+    }
+
+    #[test]
+    fn error_line_sums_counters_across_links() {
+        let links = vec![
+            make_link(
+                0,
+                true,
+                RemoteDeviceType::Switch,
+                Some("0000:01:00.0"),
+                None,
+                None,
+                Some(3),
+                Some(5),
+                Some(2),
+                Some(4),
+            ),
+            make_link(
+                1,
+                true,
+                RemoteDeviceType::Switch,
+                Some("0000:01:00.0"),
+                None,
+                None,
+                Some(7),
+                Some(11),
+                Some(13),
+                Some(4),
+            ),
+            make_link(
+                2,
+                false,
+                RemoteDeviceType::Unknown,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            ),
+        ];
+        let (port, meta) = make_port("nvidia0", links, 0.0, 0.0);
+        let tc = Theme::Default.colors();
+        let lines = build_nvlink_detail_lines(&port, &meta, None, &tc, false, 0);
+        let error_line = lines
+            .iter()
+            .find(|l| l.to_string().contains("Errors:"))
+            .expect("Errors line")
+            .to_string();
+        // crc = 3 + 7 = 10 (link 2 contributes 0)
+        assert!(
+            error_line.contains("crc=10"),
+            "crc sum wrong: {error_line:?}"
+        );
+        // replay = 5 + 11 = 16
+        assert!(
+            error_line.contains("replay=16"),
+            "replay sum wrong: {error_line:?}"
+        );
+        // recovery = 2 + 13 = 15
+        assert!(
+            error_line.contains("recovery=15"),
+            "recovery sum wrong: {error_line:?}"
+        );
+    }
+
+    #[test]
+    fn rolling_average_label_appears_when_enabled() {
+        let links = vec![make_link(
+            0,
+            true,
+            RemoteDeviceType::Switch,
+            Some("0000:01:00.0"),
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(4),
+        )];
+        let (port, meta) = make_port("nvidia0", links, 0.0, 0.0);
+        let tc = Theme::Default.colors();
+        let lines = build_nvlink_detail_lines(&port, &meta, None, &tc, true, 5);
+        let header = lines[0].to_string();
+        assert!(
+            header.contains("[avg 5s]"),
+            "rolling avg label missing: {header:?}"
+        );
+    }
+
+    #[test]
+    fn header_and_lanes_show_aggregate_rates() {
+        // Two active links and one inactive link. The aggregate must appear
+        // in the header (in Gbps) and be repeated identically in every lane
+        // row (in MB/s) — NVML does not expose per-lane throughput.
+        let links = vec![
+            make_link(
+                0,
+                true,
+                RemoteDeviceType::Switch,
+                Some("0000:01:00.0"),
+                None,
+                None,
+                None,
+                None,
+                None,
+                Some(3),
+            ),
+            make_link(
+                1,
+                true,
+                RemoteDeviceType::Gpu,
+                Some("0000:02:00.0"),
+                None,
+                None,
+                None,
+                None,
+                None,
+                Some(3),
+            ),
+            make_link(
+                2,
+                false,
+                RemoteDeviceType::Unknown,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            ),
+        ];
+        // Build a PortThroughput with non-zero aggregate rates. `make_port`
+        // hardcodes the aggregate to 0.0, so construct it inline.
+        let meta = NvLinkThroughputMeta {
+            gpu_index: 0,
+            gpu_name: "H100".to_string(),
+            active_links: 2,
+            links: links.clone(),
+        };
+        let port = PortThroughput {
+            dev_name: "nvidia0".to_string(),
+            port: 2,
+            link_gbps: Some(100.0),
+            tx_gbps: 1.0,
+            rx_gbps: 1.0,
+            tx_pkts_per_sec: 0.0,
+            rx_pkts_per_sec: 0.0,
+            rx_drops_per_sec: 0.0,
+            counter_rates: Vec::new(),
+            port_label: Some("2/3".to_string()),
+            nvlink: Some(meta.clone()),
+        };
+
+        let tc = Theme::Default.colors();
+        let lines = build_nvlink_detail_lines(&port, &meta, None, &tc, false, 0);
+
+        // Header aggregate lines must contain the Gbps string.
+        let tx_line = lines[1].to_string();
+        let rx_line = lines[2].to_string();
+        assert!(
+            tx_line.contains("1.00 Gbps"),
+            "TX header missing aggregate rate: {tx_line:?}"
+        );
+        assert!(
+            rx_line.contains("1.00 Gbps"),
+            "RX header missing aggregate rate: {rx_line:?}"
+        );
+
+        // Compute the expected MB/s value: gbps * 1000 / 8 = 125.0.
+        let expected_mb_s = "125.0";
+
+        // Muted note line must be present before the lane table.
+        let blob = join_lines(&lines);
+        assert!(
+            blob.contains("Per-lane throughput is not available from NVML"),
+            "missing muted note about per-lane throughput: {blob}"
+        );
+
+        // Each lane row must contain the aggregate MB/s value. Look up rows
+        // by their link id and verify both TX and RX columns render 125.0.
+        for link in &links {
+            let lane_row = lines
+                .iter()
+                .find(|l| {
+                    let s = l.to_string();
+                    s.contains(&format!("{:>4}", link.link_id))
+                })
+                .unwrap_or_else(|| panic!("missing lane row for link {}", link.link_id))
+                .to_string();
+            // The MB/s value is rendered as `{:>6.1}` so it appears as
+            // " 125.0" (leading space from the width spec).
+            assert!(
+                lane_row.contains(&format!("{}", expected_mb_s)),
+                "lane {} row missing aggregate MB/s value {}: {:?}",
+                link.link_id,
+                expected_mb_s,
+                lane_row
+            );
+        }
+
+        // The MB/s value must appear in every lane row — that's three
+        // occurrences total (one per link).
+        let occurrences = lines
+            .iter()
+            .filter(|l| l.to_string().contains(expected_mb_s))
+            .count();
+        assert_eq!(
+            occurrences, 3,
+            "expected the aggregate MB/s value in 3 lane rows, got {occurrences}"
+        );
     }
 }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1535,8 +1535,14 @@ mod nvlink_detail_tests {
             .find(|l| l.to_string().starts_with("    0 "))
             .unwrap()
             .to_string();
-        assert!(lane0_row.contains("  10.0"), "lane 0 missing TX: {lane0_row:?}");
-        assert!(lane0_row.contains("  20.0"), "lane 0 missing RX: {lane0_row:?}");
+        assert!(
+            lane0_row.contains("  10.0"),
+            "lane 0 missing TX: {lane0_row:?}"
+        );
+        assert!(
+            lane0_row.contains("  20.0"),
+            "lane 0 missing RX: {lane0_row:?}"
+        );
 
         // lane 1 row should contain "  30.0" and "  40.0"
         let lane1_row = lines
@@ -1544,7 +1550,13 @@ mod nvlink_detail_tests {
             .find(|l| l.to_string().starts_with("    1 "))
             .unwrap()
             .to_string();
-        assert!(lane1_row.contains("  30.0"), "lane 1 missing TX: {lane1_row:?}");
-        assert!(lane1_row.contains("  40.0"), "lane 1 missing RX: {lane1_row:?}");
+        assert!(
+            lane1_row.contains("  30.0"),
+            "lane 1 missing TX: {lane1_row:?}"
+        );
+        assert!(
+            lane1_row.contains("  40.0"),
+            "lane 1 missing RX: {lane1_row:?}"
+        );
     }
 }


### PR DESCRIPTION
Introduces NVLink monitoring panel to the rdmatop, allowing users to track link-level throughput, physical status, and error counters across NVIDIA GPU architectures.
- **Optional Compilation**
Isolated all NVIDIA dependencies behind a new, optional nvlink Cargo feature flag (`nvml-wrapper` and `nvml-wrapper-sys`) to ensure clean builds on CPU-only or non-NVIDIA systems.

- **Direct NVML Interop (`src/nvlink.rs`)**
Implemented lightweight snapshot structures (`NvLinkSnapshot`, `LinkSnapshot`) utilizing raw FFI calls to `nvmlDeviceGetFieldValues` to bypass safe-wrapper limits and fetch precise TX/RX throughput data.

- **Bandwidth Aggregation & Fallbacks (`src/tui/app.rs`)**
Tracks counter deltas over time to compute individual, per-lane bandwidth rates. Automatically falls back to driver-level GPU-wide aggregates or averages when link-specific tracking isn't supported.

- **NVLink TUI Panel (`src/tui/ui.rs`)**
Added an interactive sub-view (triggered by pressing Enter on a device) featuring:
  - Active/total link statuses and interval averages.
  - Real-time TX/RX bandwidth sparklines.
  - A comprehensive Lane Details table mapping link state, protocol versions, live throughput, and remote device BDFs (GPUs or NVSwitches).
  - Aggregated hardware error counters (CRC, replay, recovery) to surface immediate connectivity issues.