### PR TITLE
feat: support AMD XGMI monitoring

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ categories = ["network-programming", "command-line-utilities"]
 
 [features]
 nvlink = ["dep:nvml-wrapper", "dep:nvml-wrapper-sys"]
+xgmi = ["dep:libloading"]
 
 [profile.release]
 strip = true
@@ -28,3 +29,4 @@ ratatui = "0.30"
 crossterm = "0.29"
 nvml-wrapper = { version = "0.12.1", optional = true }
 nvml-wrapper-sys = { version = "0.9.1", optional = true }
+libloading = { version = "0.8", optional = true }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,9 @@ mod tui;
 #[cfg(feature = "nvlink")]
 mod nvlink;
 
+#[cfg(feature = "xgmi")]
+mod xgmi;
+
 use std::io;
 use std::time::Instant;
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -26,6 +26,26 @@ pub struct PortThroughput {
     /// by the TUI detail pane when the `nvlink` feature is enabled.
     #[cfg(feature = "nvlink")]
     pub nvlink: Option<NvLinkThroughputMeta>,
+    /// XGMI metadata attached to this row when the `xgmi` feature is enabled.
+    #[cfg(feature = "xgmi")]
+    pub xgmi: Option<XgmiThroughputMeta>,
+}
+
+/// Per-GPU XGMI metadata attached to a `PortThroughput` row when the
+/// `xgmi` feature is enabled. Mirrors `NvLinkThroughputMeta`; `links[]`
+/// tx/rx are rewritten as per-second byte rates for the detail pane.
+#[cfg(feature = "xgmi")]
+#[derive(Clone, Debug)]
+pub struct XgmiThroughputMeta {
+    /// Not rendered yet (rows already show `amdgpu<index>` via `dev_name`);
+    /// kept so future panels (e.g. topology graph) can reference it.
+    #[allow(dead_code)]
+    pub gpu_index: u32,
+    /// Marketing name (e.g. "AMD Instinct MI325X"); kept for future panels.
+    #[allow(dead_code)]
+    pub gpu_name: String,
+    pub active_links: u32,
+    pub links: Vec<crate::xgmi::XgmiLinkSnapshot>,
 }
 
 /// Per-GPU NVLink metadata attached to a `PortThroughput` row when the
@@ -233,6 +253,8 @@ impl RollingAvgState {
             port_label: latest.port_label.clone(),
             #[cfg(feature = "nvlink")]
             nvlink: latest.nvlink.clone(),
+            #[cfg(feature = "xgmi")]
+            xgmi: latest.xgmi.clone(),
         };
         if let Some(template) = window.last() {
             avg.counter_rates = template
@@ -333,6 +355,8 @@ pub struct App {
     pub record_status: Option<String>,
     #[cfg(feature = "nvlink")]
     prev_nvlink: Vec<crate::nvlink::NvLinkSnapshot>,
+    #[cfg(feature = "xgmi")]
+    prev_xgmi: Vec<crate::xgmi::XgmiSnapshot>,
 }
 
 const HISTORY_LEN: usize = 60;
@@ -409,6 +433,11 @@ impl App {
             record_status: None,
             #[cfg(feature = "nvlink")]
             prev_nvlink: Vec::new(),
+            // Pre-read like prev_stats above: XGMI accumulators are lifetime
+            // TB-scale, so an empty baseline would render an absurd first-
+            // frame rate spike (whole accumulator / one interval).
+            #[cfg(feature = "xgmi")]
+            prev_xgmi: crate::xgmi::read_all_xgmi_stats().unwrap_or_default(),
         }
     }
 
@@ -431,6 +460,14 @@ impl App {
                 compute_nvlink_throughputs(&self.prev_nvlink, &curr_nvlink, elapsed);
             self.throughputs.append(&mut nvlink_rows);
             self.prev_nvlink = curr_nvlink;
+        }
+
+        #[cfg(feature = "xgmi")]
+        {
+            let curr_xgmi = crate::xgmi::read_all_xgmi_stats().unwrap_or_default();
+            let mut xgmi_rows = compute_xgmi_throughputs(&self.prev_xgmi, &curr_xgmi, elapsed);
+            self.throughputs.append(&mut xgmi_rows);
+            self.prev_xgmi = curr_xgmi;
         }
 
         // Stable display order: sort once here so history, rolling averages,
@@ -867,6 +904,8 @@ fn compute_port_throughput(
         port_label: None,
         #[cfg(feature = "nvlink")]
         nvlink: None,
+        #[cfg(feature = "xgmi")]
+        xgmi: None,
     }
 }
 
@@ -878,13 +917,15 @@ fn compute_throughputs(prev: &[PortStat], curr: &[PortStat], elapsed: f64) -> Ve
 
 /// Stable identity key for a `PortThroughput` row across refreshes.
 ///
-/// For NVLink rows the `port` field encodes the active-link count, which can
-/// change between samples even when the underlying GPU is the same. Using
-/// `dev_name` alone keeps the key (and therefore sort order and rolling-avg
-/// history) stable across those changes.
+/// NVLink and XGMI rows key by `dev_name` alone because their `port` field
+/// encodes the active-link count, which can change between samples.
 fn throughput_key(t: &PortThroughput) -> String {
     #[cfg(feature = "nvlink")]
     if t.nvlink.is_some() {
+        return t.dev_name.clone();
+    }
+    #[cfg(feature = "xgmi")]
+    if t.xgmi.is_some() {
         return t.dev_name.clone();
     }
     format!("{}/{}", t.dev_name, t.port)
@@ -1045,9 +1086,213 @@ fn compute_nvlink_throughputs(
                 active_links: active,
                 links,
             }),
+            #[cfg(feature = "xgmi")]
+            xgmi: None,
         });
     }
     out
+}
+
+/// Compute one `PortThroughput` row per GPU from a pair of XGMI snapshots.
+/// amdsmi reports true per-link accumulators, so GPU totals are the sum of
+/// per-link deltas; meta links carry per-second byte rates for the pane.
+#[cfg(feature = "xgmi")]
+fn compute_xgmi_throughputs(
+    prev: &[crate::xgmi::XgmiSnapshot],
+    curr: &[crate::xgmi::XgmiSnapshot],
+    elapsed: f64,
+) -> Vec<PortThroughput> {
+    let mut out = Vec::with_capacity(curr.len());
+    for gpu in curr {
+        let prev_gpu = prev.iter().find(|p| p.gpu_index == gpu.gpu_index);
+
+        let mut tx_total: u64 = 0;
+        let mut rx_total: u64 = 0;
+        let mut links = Vec::with_capacity(gpu.links.len());
+        for link in &gpu.links {
+            let prev_link =
+                prev_gpu.and_then(|p| p.links.iter().find(|l| l.link_id == link.link_id));
+            let tx_delta = link
+                .tx_bytes
+                .unwrap_or(0)
+                .saturating_sub(prev_link.and_then(|l| l.tx_bytes).unwrap_or(0));
+            let rx_delta = link
+                .rx_bytes
+                .unwrap_or(0)
+                .saturating_sub(prev_link.and_then(|l| l.rx_bytes).unwrap_or(0));
+            tx_total = tx_total.saturating_add(tx_delta);
+            rx_total = rx_total.saturating_add(rx_delta);
+
+            let mut link_rate = link.clone();
+            link_rate.tx_bytes = Some((tx_delta as f64 / elapsed) as u64);
+            link_rate.rx_bytes = Some((rx_delta as f64 / elapsed) as u64);
+            links.push(link_rate);
+        }
+
+        let mut counter_rates: Vec<CounterRate> = Vec::new();
+        if let Some(v) = gpu.correctable_errors {
+            let prev_v = prev_gpu.and_then(|p| p.correctable_errors).unwrap_or(0);
+            let delta = v.saturating_sub(prev_v);
+            counter_rates.push(CounterRate {
+                name: "xgmi_wafl_ce".to_string(),
+                value: v,
+                delta,
+                rate: delta as f64 / elapsed,
+                is_bytes: false,
+            });
+        }
+        if let Some(v) = gpu.uncorrectable_errors {
+            let prev_v = prev_gpu.and_then(|p| p.uncorrectable_errors).unwrap_or(0);
+            let delta = v.saturating_sub(prev_v);
+            counter_rates.push(CounterRate {
+                name: "xgmi_wafl_ue".to_string(),
+                value: v,
+                delta,
+                rate: delta as f64 / elapsed,
+                is_bytes: false,
+            });
+        }
+
+        let active = gpu.active_links();
+        out.push(PortThroughput {
+            dev_name: format!("amdgpu{}", gpu.gpu_index),
+            port: active,
+            link_gbps: gpu.link_gbps,
+            tx_gbps: bytes_to_gbps(tx_total as f64 / elapsed),
+            rx_gbps: bytes_to_gbps(rx_total as f64 / elapsed),
+            tx_pkts_per_sec: 0.0,
+            rx_pkts_per_sec: 0.0,
+            rx_drops_per_sec: 0.0,
+            counter_rates,
+            port_label: Some(format!("{}/{}", active, gpu.link_count)),
+            #[cfg(feature = "nvlink")]
+            nvlink: None,
+            xgmi: Some(XgmiThroughputMeta {
+                gpu_index: gpu.gpu_index,
+                gpu_name: gpu.gpu_name.clone(),
+                active_links: active,
+                links,
+            }),
+        });
+    }
+    out
+}
+
+#[cfg(all(test, feature = "xgmi"))]
+mod xgmi_tests {
+    use super::*;
+    use crate::xgmi::{XgmiLinkSnapshot, XgmiSnapshot};
+
+    fn mk_link(id: u32, active: bool, tx: u64, rx: u64) -> XgmiLinkSnapshot {
+        XgmiLinkSnapshot {
+            link_id: id,
+            is_active: active,
+            speed_gbps: Some(512.0),
+            bit_rate_gbps: Some(32.0),
+            remote_pci_bdf: Some(format!("0000:0{}:00.0", id + 1)),
+            tx_bytes: Some(tx),
+            rx_bytes: Some(rx),
+        }
+    }
+
+    fn mk_gpu(index: u32, links: Vec<XgmiLinkSnapshot>) -> XgmiSnapshot {
+        let active: u32 = links.iter().filter(|l| l.is_active).count() as u32;
+        XgmiSnapshot {
+            gpu_index: index,
+            gpu_name: "MI325X".to_string(),
+            link_count: links.len() as u32,
+            link_gbps: Some(512.0 * active as f64),
+            correctable_errors: Some(0),
+            uncorrectable_errors: Some(0),
+            links,
+        }
+    }
+
+    #[test]
+    fn totals_are_sum_of_link_deltas() {
+        let prev = vec![mk_gpu(
+            0,
+            vec![mk_link(0, true, 1000, 2000), mk_link(1, true, 500, 500)],
+        )];
+        let curr = vec![mk_gpu(
+            0,
+            vec![mk_link(0, true, 3000, 6000), mk_link(1, true, 1500, 1500)],
+        )];
+        let rows = compute_xgmi_throughputs(&prev, &curr, 1.0);
+        assert_eq!(rows.len(), 1);
+        let row = &rows[0];
+        assert_eq!(row.dev_name, "amdgpu0");
+        // tx delta = (3000-1000)+(1500-500) = 3000 B/s; rx = 4000+1000 = 5000 B/s
+        assert!((row.tx_gbps - bytes_to_gbps(3000.0)).abs() < 1e-12);
+        assert!((row.rx_gbps - bytes_to_gbps(5000.0)).abs() < 1e-12);
+        assert_eq!(row.port_label.as_deref(), Some("2/2"));
+        // meta links carry per-second rates now
+        let meta = row.xgmi.as_ref().expect("xgmi meta present");
+        assert_eq!(meta.links[0].tx_bytes, Some(2000));
+        assert_eq!(meta.links[0].rx_bytes, Some(4000));
+        assert_eq!(meta.links[1].tx_bytes, Some(1000));
+        assert_eq!(meta.links[1].rx_bytes, Some(1000));
+    }
+
+    #[test]
+    fn first_sample_uses_zero_prev() {
+        let curr = vec![mk_gpu(0, vec![mk_link(0, true, 4096, 8192)])];
+        let rows = compute_xgmi_throughputs(&[], &curr, 2.0);
+        let row = &rows[0];
+        assert!((row.tx_gbps - bytes_to_gbps(2048.0)).abs() < 1e-12);
+        assert!((row.rx_gbps - bytes_to_gbps(4096.0)).abs() < 1e-12);
+    }
+
+    #[test]
+    fn counter_going_backwards_clamps_to_zero() {
+        let prev = vec![mk_gpu(0, vec![mk_link(0, true, 9999, 9999)])];
+        let curr = vec![mk_gpu(0, vec![mk_link(0, true, 1, 1)])];
+        let rows = compute_xgmi_throughputs(&prev, &curr, 1.0);
+        assert_eq!(rows[0].tx_gbps, 0.0);
+        assert_eq!(rows[0].rx_gbps, 0.0);
+    }
+
+    #[test]
+    fn inactive_links_excluded_from_active_count() {
+        let curr = vec![mk_gpu(
+            0,
+            vec![mk_link(0, true, 0, 0), mk_link(1, false, 0, 0)],
+        )];
+        let rows = compute_xgmi_throughputs(&[], &curr, 1.0);
+        assert_eq!(rows[0].port, 1);
+        assert_eq!(rows[0].port_label.as_deref(), Some("1/2"));
+    }
+
+    #[test]
+    fn wafl_error_counters_emitted_with_deltas() {
+        let mut prev_gpu = mk_gpu(0, vec![mk_link(0, true, 0, 0)]);
+        prev_gpu.correctable_errors = Some(5);
+        prev_gpu.uncorrectable_errors = Some(1);
+        let mut curr_gpu = mk_gpu(0, vec![mk_link(0, true, 0, 0)]);
+        curr_gpu.correctable_errors = Some(8);
+        curr_gpu.uncorrectable_errors = Some(1);
+        let rows = compute_xgmi_throughputs(&[prev_gpu], &[curr_gpu], 1.0);
+        let ce = rows[0]
+            .counter_rates
+            .iter()
+            .find(|c| c.name == "xgmi_wafl_ce")
+            .unwrap();
+        assert_eq!(ce.value, 8);
+        assert_eq!(ce.delta, 3);
+        let ue = rows[0]
+            .counter_rates
+            .iter()
+            .find(|c| c.name == "xgmi_wafl_ue")
+            .unwrap();
+        assert_eq!(ue.value, 1);
+        assert_eq!(ue.delta, 0);
+    }
+
+    #[test]
+    fn throughput_key_uses_dev_name_for_xgmi_rows() {
+        let rows = compute_xgmi_throughputs(&[], &[mk_gpu(3, vec![mk_link(0, true, 0, 0)])], 1.0);
+        assert_eq!(throughput_key(&rows[0]), "amdgpu3");
+    }
 }
 
 #[cfg(all(test, feature = "nvlink"))]
@@ -1595,6 +1840,8 @@ mod nvlink_tests {
                 active_links: 2,
                 links: Vec::new(),
             }),
+            #[cfg(feature = "xgmi")]
+            xgmi: None,
         };
         let rdma_a_ref = PortThroughput {
             dev_name: "mlx5_0".to_string(),
@@ -1609,6 +1856,8 @@ mod nvlink_tests {
             port_label: None,
             #[cfg(feature = "nvlink")]
             nvlink: None,
+            #[cfg(feature = "xgmi")]
+            xgmi: None,
         };
         let rdma_b_ref = PortThroughput {
             dev_name: "mlx5_1".to_string(),
@@ -1623,6 +1872,8 @@ mod nvlink_tests {
             port_label: None,
             #[cfg(feature = "nvlink")]
             nvlink: None,
+            #[cfg(feature = "xgmi")]
+            xgmi: None,
         };
         let reference = vec![rdma_a_ref.clone(), nvlink_ref.clone(), rdma_b_ref.clone()];
         let nvlink_ref_pos = 1usize;
@@ -1647,6 +1898,8 @@ mod nvlink_tests {
                 active_links: 3,
                 links: Vec::new(),
             }),
+            #[cfg(feature = "xgmi")]
+            xgmi: None,
         };
         let rdma_a_avg = PortThroughput {
             dev_name: "mlx5_0".to_string(),
@@ -1661,6 +1914,8 @@ mod nvlink_tests {
             port_label: None,
             #[cfg(feature = "nvlink")]
             nvlink: None,
+            #[cfg(feature = "xgmi")]
+            xgmi: None,
         };
         let rdma_b_avg = PortThroughput {
             dev_name: "mlx5_1".to_string(),
@@ -1675,6 +1930,8 @@ mod nvlink_tests {
             port_label: None,
             #[cfg(feature = "nvlink")]
             nvlink: None,
+            #[cfg(feature = "xgmi")]
+            xgmi: None,
         };
         let mut avgs = vec![rdma_b_avg.clone(), nvlink_avg.clone(), rdma_a_avg.clone()];
 
@@ -1715,6 +1972,8 @@ mod sort_tests {
             port_label: None,
             #[cfg(feature = "nvlink")]
             nvlink: None,
+            #[cfg(feature = "xgmi")]
+            xgmi: None,
         }
     }
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -431,11 +431,11 @@ impl App {
             cached_display: Vec::new(),
             recorder: None,
             record_status: None,
+            // Pre-read like prev_stats above: NVML/amdsmi counters are
+            // cumulative since driver load, so an empty baseline would
+            // render an absurd first-frame rate spike.
             #[cfg(feature = "nvlink")]
-            prev_nvlink: Vec::new(),
-            // Pre-read like prev_stats above: XGMI accumulators are lifetime
-            // TB-scale, so an empty baseline would render an absurd first-
-            // frame rate spike (whole accumulator / one interval).
+            prev_nvlink: crate::nvlink::read_all_nvlink_stats().unwrap_or_default(),
             #[cfg(feature = "xgmi")]
             prev_xgmi: crate::xgmi::read_all_xgmi_stats().unwrap_or_default(),
         }
@@ -952,9 +952,10 @@ fn sort_by_throughput_order(avgs: &mut [PortThroughput], reference: &[PortThroug
 
 /// Compute one `PortThroughput` row per GPU from a pair of NVLink snapshots.
 ///
-/// The previous snapshot is looked up by `gpu_index`. Missing previous links
-/// (or `None` byte counters) are treated as zero so a freshly-observed GPU
-/// surfaces its full current byte counts as the first delta.
+/// The previous snapshot is looked up by `gpu_index`. A GPU, link, or
+/// counter without a prior sample emits a zero delta: NVML counters are
+/// cumulative since driver load, so diffing against zero would render an
+/// absurd rate spike (same convention as `compute_xgmi_throughputs`).
 ///
 /// NVML exposes `NVML_FI_DEV_NVLINK_THROUGHPUT_DATA_TX/RX` as a *GPU-wide*
 /// aggregate, not per-link counters. Each link in `LinkSnapshot::tx_bytes` /
@@ -971,6 +972,12 @@ fn compute_nvlink_throughputs(
     curr: &[crate::nvlink::NvLinkSnapshot],
     elapsed: f64,
 ) -> Vec<PortThroughput> {
+    // Both samples must exist to diff: a counter reappearing after a gap
+    // would otherwise diff its cumulative value against zero.
+    let delta = |c: Option<u64>, p: Option<u64>| match (c, p) {
+        (Some(c), Some(p)) => c.saturating_sub(p),
+        _ => 0,
+    };
     let mut out = Vec::with_capacity(curr.len());
     for gpu in curr {
         let prev_gpu = prev.iter().find(|p| p.gpu_index == gpu.gpu_index);
@@ -978,13 +985,9 @@ fn compute_nvlink_throughputs(
 
         // Calculate GPU-wide aggregate throughput, preferring the u32::MAX aggregate fields.
         let (tx_bytes_total, rx_bytes_total) = if gpu.tx_bytes.is_some() || gpu.rx_bytes.is_some() {
-            let curr_tx = gpu.tx_bytes.unwrap_or(0);
-            let prev_tx = prev_gpu.and_then(|p| p.tx_bytes).unwrap_or(0);
-            let curr_rx = gpu.rx_bytes.unwrap_or(0);
-            let prev_rx = prev_gpu.and_then(|p| p.rx_bytes).unwrap_or(0);
             (
-                curr_tx.saturating_sub(prev_tx),
-                curr_rx.saturating_sub(prev_rx),
+                delta(gpu.tx_bytes, prev_gpu.and_then(|p| p.tx_bytes)),
+                delta(gpu.rx_bytes, prev_gpu.and_then(|p| p.rx_bytes)),
             )
         } else {
             // Fallback: Pick a single link to source the GPU-wide TX/RX aggregate from.
@@ -997,35 +1000,29 @@ fn compute_nvlink_throughputs(
                 Some(link) => {
                     let prev_link =
                         prev_gpu.and_then(|p| p.links.iter().find(|l| l.link_id == link.link_id));
-                    let curr_tx = link.tx_bytes.unwrap_or(0);
-                    let prev_tx = prev_link.and_then(|l| l.tx_bytes).unwrap_or(0);
-                    let curr_rx = link.rx_bytes.unwrap_or(0);
-                    let prev_rx = prev_link.and_then(|l| l.rx_bytes).unwrap_or(0);
                     (
-                        curr_tx.saturating_sub(prev_tx),
-                        curr_rx.saturating_sub(prev_rx),
+                        delta(link.tx_bytes, prev_link.and_then(|l| l.tx_bytes)),
+                        delta(link.rx_bytes, prev_link.and_then(|l| l.rx_bytes)),
                     )
                 }
                 None => (0, 0),
             }
         };
 
-        // Compute individual link rates in bytes per second to store in the metadata links
+        // Compute individual link rates in bytes per second to store in the
+        // metadata links. `None` counters stay `None` so the detail pane can
+        // use its GPU-aggregate fallback instead of showing a false 0.
+        let rate = |c: Option<u64>, p: Option<u64>| -> Option<u64> {
+            c.map(|_| (delta(c, p) as f64 / elapsed) as u64)
+        };
         let mut links = Vec::with_capacity(gpu.links.len());
         for link in &gpu.links {
             let prev_link =
                 prev_gpu.and_then(|p| p.links.iter().find(|l| l.link_id == link.link_id));
-            let curr_tx = link.tx_bytes.unwrap_or(0);
-            let prev_tx = prev_link.and_then(|l| l.tx_bytes).unwrap_or(0);
-            let curr_rx = link.rx_bytes.unwrap_or(0);
-            let prev_rx = prev_link.and_then(|l| l.rx_bytes).unwrap_or(0);
-
-            let rate_tx = (curr_tx.saturating_sub(prev_tx) as f64 / elapsed) as u64;
-            let rate_rx = (curr_rx.saturating_sub(prev_rx) as f64 / elapsed) as u64;
 
             let mut link_clone = link.clone();
-            link_clone.tx_bytes = Some(rate_tx);
-            link_clone.rx_bytes = Some(rate_rx);
+            link_clone.tx_bytes = rate(link.tx_bytes, prev_link.and_then(|l| l.tx_bytes));
+            link_clone.rx_bytes = rate(link.rx_bytes, prev_link.and_then(|l| l.rx_bytes));
             links.push(link_clone);
         }
 
@@ -1034,35 +1031,41 @@ fn compute_nvlink_throughputs(
                 prev_gpu.and_then(|p| p.links.iter().find(|l| l.link_id == link.link_id));
 
             if let Some(v) = link.crc_error_count {
-                let prev_v = prev_link.and_then(|l| l.crc_error_count).unwrap_or(0);
-                let delta = v.saturating_sub(prev_v);
+                let d = delta(
+                    link.crc_error_count,
+                    prev_link.and_then(|l| l.crc_error_count),
+                );
                 counter_rates.push(CounterRate {
                     name: format!("nvlink_crc_l{}", link.link_id),
                     value: v,
-                    delta,
-                    rate: delta as f64 / elapsed,
+                    delta: d,
+                    rate: d as f64 / elapsed,
                     is_bytes: false,
                 });
             }
             if let Some(v) = link.replay_error_count {
-                let prev_v = prev_link.and_then(|l| l.replay_error_count).unwrap_or(0);
-                let delta = v.saturating_sub(prev_v);
+                let d = delta(
+                    link.replay_error_count,
+                    prev_link.and_then(|l| l.replay_error_count),
+                );
                 counter_rates.push(CounterRate {
                     name: format!("nvlink_replay_l{}", link.link_id),
                     value: v,
-                    delta,
-                    rate: delta as f64 / elapsed,
+                    delta: d,
+                    rate: d as f64 / elapsed,
                     is_bytes: false,
                 });
             }
             if let Some(v) = link.recovery_error_count {
-                let prev_v = prev_link.and_then(|l| l.recovery_error_count).unwrap_or(0);
-                let delta = v.saturating_sub(prev_v);
+                let d = delta(
+                    link.recovery_error_count,
+                    prev_link.and_then(|l| l.recovery_error_count),
+                );
                 counter_rates.push(CounterRate {
                     name: format!("nvlink_recovery_l{}", link.link_id),
                     value: v,
-                    delta,
-                    rate: delta as f64 / elapsed,
+                    delta: d,
+                    rate: d as f64 / elapsed,
                     is_bytes: false,
                 });
             }
@@ -1564,7 +1567,9 @@ mod nvlink_tests {
     }
 
     #[test]
-    fn missing_prev_snapshot_treats_curr_as_delta() {
+    fn missing_prev_snapshot_emits_zero_rates() {
+        // NVML counters are cumulative since driver load: a GPU with no
+        // prior sample must not diff them against zero (rate spike).
         let elapsed = 2.0_f64;
         let curr = vec![NvLinkSnapshot {
             gpu_index: 1,
@@ -1581,10 +1586,8 @@ mod nvlink_tests {
         let row = &rows[0];
         assert_eq!(row.dev_name, "nvidia1");
         assert_eq!(row.port_label.as_deref(), Some("1/1"));
-        let expected_tx = 2_000_000_000.0_f64 * 8.0 / 1_000_000_000.0 / elapsed;
-        let expected_rx = 1_000_000_000.0_f64 * 8.0 / 1_000_000_000.0 / elapsed;
-        assert!((row.tx_gbps - expected_tx).abs() < 1e-6);
-        assert!((row.rx_gbps - expected_rx).abs() < 1e-6);
+        assert_eq!(row.tx_gbps, 0.0);
+        assert_eq!(row.rx_gbps, 0.0);
     }
 
     #[test]

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1109,30 +1109,42 @@ fn compute_xgmi_throughputs(
         let mut tx_total: u64 = 0;
         let mut rx_total: u64 = 0;
         let mut links = Vec::with_capacity(gpu.links.len());
+        // Both samples must exist to diff: a link or counter reappearing
+        // after a gap would otherwise diff its lifetime TB-scale
+        // accumulator against zero and render an absurd rate spike.
+        let delta = |c: Option<u64>, p: Option<u64>| match (c, p) {
+            (Some(c), Some(p)) => c.saturating_sub(p),
+            _ => 0,
+        };
         for link in &gpu.links {
             let prev_link =
                 prev_gpu.and_then(|p| p.links.iter().find(|l| l.link_id == link.link_id));
-            let tx_delta = link
-                .tx_bytes
-                .unwrap_or(0)
-                .saturating_sub(prev_link.and_then(|l| l.tx_bytes).unwrap_or(0));
-            let rx_delta = link
-                .rx_bytes
-                .unwrap_or(0)
-                .saturating_sub(prev_link.and_then(|l| l.rx_bytes).unwrap_or(0));
+            let (tx_delta, rx_delta) = match prev_link {
+                Some(pl) => (
+                    delta(link.tx_bytes, pl.tx_bytes),
+                    delta(link.rx_bytes, pl.rx_bytes),
+                ),
+                None => (0, 0),
+            };
             tx_total = tx_total.saturating_add(tx_delta);
             rx_total = rx_total.saturating_add(rx_delta);
 
+            // Keep "no counter data" as None so the pane can show "-"
+            // instead of a fabricated 0.0 rate.
             let mut link_rate = link.clone();
-            link_rate.tx_bytes = Some((tx_delta as f64 / elapsed) as u64);
-            link_rate.rx_bytes = Some((rx_delta as f64 / elapsed) as u64);
+            link_rate.tx_bytes = link.tx_bytes.map(|_| (tx_delta as f64 / elapsed) as u64);
+            link_rate.rx_bytes = link.rx_bytes.map(|_| (rx_delta as f64 / elapsed) as u64);
             links.push(link_rate);
         }
 
         let mut counter_rates: Vec<CounterRate> = Vec::new();
         if let Some(v) = gpu.correctable_errors {
-            let prev_v = prev_gpu.and_then(|p| p.correctable_errors).unwrap_or(0);
-            let delta = v.saturating_sub(prev_v);
+            // Missing prev => zero delta, same convention as the byte
+            // counters above (the accumulated total still shows in `value`).
+            let delta = match prev_gpu.and_then(|p| p.correctable_errors) {
+                Some(prev_v) => v.saturating_sub(prev_v),
+                None => 0,
+            };
             counter_rates.push(CounterRate {
                 name: "xgmi_wafl_ce".to_string(),
                 value: v,
@@ -1142,8 +1154,10 @@ fn compute_xgmi_throughputs(
             });
         }
         if let Some(v) = gpu.uncorrectable_errors {
-            let prev_v = prev_gpu.and_then(|p| p.uncorrectable_errors).unwrap_or(0);
-            let delta = v.saturating_sub(prev_v);
+            let delta = match prev_gpu.and_then(|p| p.uncorrectable_errors) {
+                Some(prev_v) => v.saturating_sub(prev_v),
+                None => 0,
+            };
             counter_rates.push(CounterRate {
                 name: "xgmi_wafl_ue".to_string(),
                 value: v,
@@ -1235,12 +1249,48 @@ mod xgmi_tests {
     }
 
     #[test]
-    fn first_sample_uses_zero_prev() {
+    fn unseen_gpu_emits_zero_rates() {
+        // A GPU with no prior sample must not diff its lifetime accumulator
+        // against zero (would render an absurd spike mid-run).
         let curr = vec![mk_gpu(0, vec![mk_link(0, true, 4096, 8192)])];
         let rows = compute_xgmi_throughputs(&[], &curr, 2.0);
         let row = &rows[0];
-        assert!((row.tx_gbps - bytes_to_gbps(2048.0)).abs() < 1e-12);
-        assert!((row.rx_gbps - bytes_to_gbps(4096.0)).abs() < 1e-12);
+        assert_eq!(row.tx_gbps, 0.0);
+        assert_eq!(row.rx_gbps, 0.0);
+        let meta = row.xgmi.as_ref().expect("xgmi meta present");
+        assert_eq!(meta.links[0].tx_bytes, Some(0));
+        assert_eq!(meta.links[0].rx_bytes, Some(0));
+    }
+
+    #[test]
+    fn counter_reappearing_after_gap_emits_zero() {
+        // prev sample exists but carried no counter data: diffing the
+        // reappeared lifetime accumulator against zero must not spike.
+        let mut prev_link = mk_link(0, true, 0, 0);
+        prev_link.tx_bytes = None;
+        prev_link.rx_bytes = None;
+        let prev = vec![mk_gpu(0, vec![prev_link])];
+        let curr = vec![mk_gpu(
+            0,
+            vec![mk_link(0, true, u64::MAX / 2, u64::MAX / 2)],
+        )];
+        let rows = compute_xgmi_throughputs(&prev, &curr, 1.0);
+        assert_eq!(rows[0].tx_gbps, 0.0);
+        assert_eq!(rows[0].rx_gbps, 0.0);
+    }
+
+    #[test]
+    fn missing_counters_stay_none() {
+        // Peers without accumulator data must not fabricate 0.0 rates.
+        let mut link = mk_link(0, true, 0, 0);
+        link.tx_bytes = None;
+        link.rx_bytes = None;
+        let prev = vec![mk_gpu(0, vec![link.clone()])];
+        let curr = vec![mk_gpu(0, vec![link])];
+        let rows = compute_xgmi_throughputs(&prev, &curr, 1.0);
+        let meta = rows[0].xgmi.as_ref().expect("xgmi meta present");
+        assert_eq!(meta.links[0].tx_bytes, None);
+        assert_eq!(meta.links[0].rx_bytes, None);
     }
 
     #[test]

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -599,6 +599,115 @@ fn build_nvlink_detail_lines(
     lines
 }
 
+/// Build the per-link detail panel for an XGMI GPU row.
+/// Layout mirrors the NVLink pane: header, TX/RX sparklines, a link table
+/// (Link, State, Gbps, TX MB/s, RX MB/s, Remote), then XGMI_WAFL ECC counts.
+#[cfg(feature = "xgmi")]
+fn build_xgmi_detail_lines(
+    t: &PortThroughput,
+    meta: &super::app::XgmiThroughputMeta,
+    history: Option<&super::app::DeviceHistory>,
+    tc: &ThemeColors,
+    show_avg: bool,
+    avg_window: usize,
+) -> Vec<Line<'static>> {
+    let spark_w = 30;
+    let (tx_spark, rx_spark) = match history {
+        Some(h) => (sparkline_str(&h.tx, spark_w), sparkline_str(&h.rx, spark_w)),
+        None => (" ".repeat(spark_w), " ".repeat(spark_w)),
+    };
+    let avg_label = if show_avg {
+        format!("  [avg {}s]", avg_window)
+    } else {
+        String::new()
+    };
+
+    let mut lines: Vec<Line<'static>> = Vec::new();
+
+    lines.push(Line::from(vec![
+        styled(" Device: ", tc.muted, false),
+        styled(&t.dev_name, tc.accent, true),
+        styled("  [XGMI]  ", tc.accent, false),
+        styled(
+            &format!("{}/{} active", meta.active_links, meta.links.len()),
+            tc.fg,
+            false,
+        ),
+        styled(&avg_label, tc.accent, false),
+    ]));
+
+    lines.push(Line::from(vec![
+        styled(" TX: ", tc.muted, false),
+        styled(&format!("{:.2} Gbps ", t.tx_gbps), tc.good, false),
+        styled(&tx_spark, tc.good, false),
+    ]));
+    lines.push(Line::from(vec![
+        styled(" RX: ", tc.muted, false),
+        styled(&format!("{:.2} Gbps ", t.rx_gbps), tc.accent, false),
+        styled(&rx_spark, tc.accent, false),
+    ]));
+
+    lines.push(Line::from(""));
+
+    lines.push(Line::from(vec![styled(
+        " Link  State   Gbps   TX MB/s   RX MB/s  Remote",
+        tc.header_fg,
+        true,
+    )]));
+
+    for link in &meta.links {
+        let tx_mb_s = link.tx_bytes.unwrap_or(0) as f64 / 1_000_000.0;
+        let rx_mb_s = link.rx_bytes.unwrap_or(0) as f64 / 1_000_000.0;
+        let state_label = if link.is_active { "up" } else { "down" };
+        let state_color = if link.is_active { tc.good } else { tc.muted };
+        let gbps_label = link
+            .speed_gbps
+            .map(|v| format!("{:.0}", v))
+            .unwrap_or_else(|| "-".to_string());
+        // XGMI peers are always GPUs; show a bare "-" when the BDF is unknown.
+        let remote_label = link
+            .remote_pci_bdf
+            .as_ref()
+            .map(|bdf| format!("GPU {}", bdf))
+            .unwrap_or_else(|| "-".to_string());
+        lines.push(Line::from(vec![
+            styled(&format!(" {:>4}", link.link_id), tc.accent, false),
+            styled(&format!("  {:<6}", state_label), state_color, false),
+            styled(&format!("  {:>4}", gbps_label), tc.fg, false),
+            styled(&format!("  {:>7.1}", tx_mb_s), tc.fg, false),
+            styled(&format!("  {:>7.1}", rx_mb_s), tc.fg, false),
+            styled(&format!("  {}", remote_label), tc.muted, false),
+        ]));
+    }
+
+    lines.push(Line::from(""));
+
+    // XGMI_WAFL ECC counters come through counter_rates (per-GPU values).
+    let counter = |name: &str| -> u64 {
+        t.counter_rates
+            .iter()
+            .find(|c| c.name == name)
+            .map(|c| c.value)
+            .unwrap_or(0)
+    };
+    lines.push(Line::from(vec![
+        styled(" Errors: ", tc.muted, false),
+        styled(
+            &format!("wafl_ce={}", counter("xgmi_wafl_ce")),
+            tc.warning,
+            false,
+        ),
+        styled("  ", tc.muted, false),
+        styled(
+            &format!("wafl_ue={}", counter("xgmi_wafl_ue")),
+            tc.warning,
+            false,
+        ),
+    ]));
+
+    lines
+}
+
 fn build_device_header(
     t: &PortThroughput,
     history: Option<&super::app::DeviceHistory>,
@@ -705,6 +814,27 @@ fn process_line(p: &crate::stat::ProcessRdmaInfo, tc: &ThemeColors) -> Line<'sta
     ])
 }
 
+/// Pick the right detail pane builder for the selected row: NVLink pane,
+/// XGMI pane, or the generic RDMA device pane.
+fn build_selected_detail_lines(
+    t: &PortThroughput,
+    procs: &[&crate::stat::ProcessRdmaInfo],
+    history: Option<&super::app::DeviceHistory>,
+    tc: &ThemeColors,
+    show_avg: bool,
+    avg_window: usize,
+) -> Vec<Line<'static>> {
+    #[cfg(feature = "nvlink")]
+    if let Some(ref meta) = t.nvlink {
+        return build_nvlink_detail_lines(t, meta, history, tc, show_avg, avg_window);
+    }
+    #[cfg(feature = "xgmi")]
+    if let Some(ref meta) = t.xgmi {
+        return build_xgmi_detail_lines(t, meta, history, tc, show_avg, avg_window);
+    }
+    build_detail_lines(t, procs, history, tc, show_avg, avg_window)
+}
+
 fn draw_detail(frame: &mut Frame, app: &mut App, area: Rect, tc: &ThemeColors) {
     let display = app.display_throughputs();
     let t = match display.get(app.selected_row).cloned() {
@@ -724,29 +854,7 @@ fn draw_detail(frame: &mut Frame, app: &mut App, area: Rect, tc: &ThemeColors) {
     let history = app.history.get(&t.dev_name);
     let procs = app.selected_device_processes();
 
-    #[cfg(feature = "nvlink")]
-    let lines = if let Some(ref meta) = t.nvlink {
-        build_nvlink_detail_lines(
-            &t,
-            meta,
-            history,
-            tc,
-            app.show_rolling_avg,
-            app.rolling_avg.window_secs,
-        )
-    } else {
-        build_detail_lines(
-            &t,
-            &procs,
-            history,
-            tc,
-            app.show_rolling_avg,
-            app.rolling_avg.window_secs,
-        )
-    };
-
-    #[cfg(not(feature = "nvlink"))]
-    let lines = build_detail_lines(
+    let lines = build_selected_detail_lines(
         &t,
         &procs,
         history,
@@ -1129,6 +1237,8 @@ mod nvlink_detail_tests {
             counter_rates,
             port_label: Some(format!("{}/{}", active, links.len())),
             nvlink: Some(meta.clone()),
+            #[cfg(feature = "xgmi")]
+            xgmi: None,
         };
         (port, meta)
     }
@@ -1417,6 +1527,8 @@ mod nvlink_detail_tests {
             counter_rates: Vec::new(),
             port_label: Some("2/3".to_string()),
             nvlink: Some(meta.clone()),
+            #[cfg(feature = "xgmi")]
+            xgmi: None,
         };
 
         let tc = Theme::Default.colors();
@@ -1524,6 +1636,8 @@ mod nvlink_detail_tests {
             counter_rates: Vec::new(),
             port_label: Some("2/2".to_string()),
             nvlink: Some(meta.clone()),
+            #[cfg(feature = "xgmi")]
+            xgmi: None,
         };
 
         let tc = Theme::Default.colors();
@@ -1558,5 +1672,120 @@ mod nvlink_detail_tests {
             lane1_row.contains("  40.0"),
             "lane 1 missing RX: {lane1_row:?}"
         );
+    }
+}
+
+#[cfg(all(test, feature = "xgmi"))]
+mod xgmi_detail_tests {
+    use super::*;
+    use crate::tui::app::{PortThroughput, XgmiThroughputMeta};
+    use crate::tui::theme::Theme;
+    use crate::xgmi::XgmiLinkSnapshot;
+
+    fn line_text(line: &Line<'_>) -> String {
+        line.spans.iter().map(|s| s.content.as_ref()).collect()
+    }
+
+    fn mk_link(id: u32, active: bool, tx_rate: u64, rx_rate: u64) -> XgmiLinkSnapshot {
+        XgmiLinkSnapshot {
+            link_id: id,
+            is_active: active,
+            speed_gbps: Some(512.0),
+            bit_rate_gbps: Some(32.0),
+            remote_pci_bdf: Some(format!("0000:{:02x}:00.0", 0x15 + id)),
+            tx_bytes: Some(tx_rate),
+            rx_bytes: Some(rx_rate),
+        }
+    }
+
+    fn mk_row(links: Vec<XgmiLinkSnapshot>) -> (PortThroughput, XgmiThroughputMeta) {
+        let active = links.iter().filter(|l| l.is_active).count() as u32;
+        let meta = XgmiThroughputMeta {
+            gpu_index: 0,
+            gpu_name: "MI325X".to_string(),
+            active_links: active,
+            links,
+        };
+        let port = PortThroughput {
+            dev_name: "amdgpu0".to_string(),
+            port: active,
+            link_gbps: Some(512.0 * active as f64),
+            tx_gbps: 1.0,
+            rx_gbps: 2.0,
+            tx_pkts_per_sec: 0.0,
+            rx_pkts_per_sec: 0.0,
+            rx_drops_per_sec: 0.0,
+            counter_rates: vec![
+                crate::tui::app::CounterRate {
+                    name: "xgmi_wafl_ce".to_string(),
+                    value: 7,
+                    delta: 0,
+                    rate: 0.0,
+                    is_bytes: false,
+                },
+                crate::tui::app::CounterRate {
+                    name: "xgmi_wafl_ue".to_string(),
+                    value: 1,
+                    delta: 0,
+                    rate: 0.0,
+                    is_bytes: false,
+                },
+            ],
+            port_label: Some(format!("{}/{}", active, meta.links.len())),
+            #[cfg(feature = "nvlink")]
+            nvlink: None,
+            xgmi: Some(meta.clone()),
+        };
+        (port, meta)
+    }
+
+    #[test]
+    fn header_shows_device_and_active_links() {
+        let tc = Theme::Default.colors();
+        let (port, meta) = mk_row(vec![mk_link(0, true, 0, 0), mk_link(1, false, 0, 0)]);
+        let lines = build_xgmi_detail_lines(&port, &meta, None, &tc, false, 0);
+        let header = line_text(&lines[0]);
+        assert!(header.contains("amdgpu0"), "header: {header:?}");
+        assert!(header.contains("[XGMI]"), "header: {header:?}");
+        assert!(header.contains("1/2 active"), "header: {header:?}");
+    }
+
+    #[test]
+    fn per_link_rows_show_rate_and_remote() {
+        let tc = Theme::Default.colors();
+        // 2_000_000 B/s -> 2.0 MB/s
+        let (port, meta) = mk_row(vec![mk_link(0, true, 2_000_000, 4_000_000)]);
+        let lines = build_xgmi_detail_lines(&port, &meta, None, &tc, false, 0);
+        let text: Vec<String> = lines.iter().map(line_text).collect();
+        let row = text
+            .iter()
+            .find(|l| l.contains("0000:15:00.0"))
+            .expect("link row");
+        assert!(row.contains("up"), "row: {row:?}");
+        assert!(row.contains("2.0"), "row: {row:?}");
+        assert!(row.contains("4.0"), "row: {row:?}");
+    }
+
+    #[test]
+    fn inactive_link_rendered_down() {
+        let tc = Theme::Default.colors();
+        let (port, meta) = mk_row(vec![mk_link(0, false, 0, 0)]);
+        let lines = build_xgmi_detail_lines(&port, &meta, None, &tc, false, 0);
+        let text: Vec<String> = lines.iter().map(line_text).collect();
+        assert!(text.iter().any(|l| l.contains("down")), "lines: {text:?}");
+    }
+
+    #[test]
+    fn errors_line_shows_wafl_counts() {
+        let tc = Theme::Default.colors();
+        let (port, meta) = mk_row(vec![mk_link(0, true, 0, 0)]);
+        let lines = build_xgmi_detail_lines(&port, &meta, None, &tc, false, 0);
+        let text: Vec<String> = lines.iter().map(line_text).collect();
+        let err = text
+            .iter()
+            .find(|l| l.contains("wafl_ce"))
+            .expect("errors line");
+        assert!(err.contains("wafl_ce=7"), "err: {err:?}");
+        assert!(err.contains("wafl_ue=1"), "err: {err:?}");
     }
 }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -650,14 +650,17 @@ fn build_xgmi_detail_lines(
     lines.push(Line::from(""));
 
     lines.push(Line::from(vec![styled(
-        " Link  State   Gbps   TX MB/s   RX MB/s  Remote",
+        " Peer  State   Gbps   TX MB/s   RX MB/s  Remote",
         tc.header_fg,
         true,
     )]));
 
     for link in &meta.links {
-        let tx_mb_s = link.tx_bytes.unwrap_or(0) as f64 / 1_000_000.0;
-        let rx_mb_s = link.rx_bytes.unwrap_or(0) as f64 / 1_000_000.0;
+        // "-" marks counters amdsmi did not report (vs a real 0.0 rate).
+        let mb_s = |bytes: Option<u64>| match bytes {
+            Some(b) => format!("{:>7.1}", b as f64 / 1_000_000.0),
+            None => format!("{:>7}", "-"),
+        };
         let state_label = if link.is_active { "up" } else { "down" };
         let state_color = if link.is_active { tc.good } else { tc.muted };
         let gbps_label = link
@@ -674,8 +677,8 @@ fn build_xgmi_detail_lines(
             styled(&format!(" {:>4}", link.link_id), tc.accent, false),
             styled(&format!("  {:<6}", state_label), state_color, false),
             styled(&format!("  {:>4}", gbps_label), tc.fg, false),
-            styled(&format!("  {:>7.1}", tx_mb_s), tc.fg, false),
-            styled(&format!("  {:>7.1}", rx_mb_s), tc.fg, false),
+            styled(&format!("  {}", mb_s(link.tx_bytes)), tc.fg, false),
+            styled(&format!("  {}", mb_s(link.rx_bytes)), tc.fg, false),
             styled(&format!("  {}", remote_label), tc.muted, false),
         ]));
     }
@@ -1570,7 +1573,7 @@ mod nvlink_detail_tests {
             // The MB/s value is rendered as `{:>6.1}` so it appears as
             // " 125.0" (leading space from the width spec).
             assert!(
-                lane_row.contains(&format!("{}", expected_mb_s)),
+                lane_row.contains(&expected_mb_s.to_string()),
                 "lane {} row missing aggregate MB/s value {}: {:?}",
                 link.link_id,
                 expected_mb_s,
@@ -1787,5 +1790,22 @@ mod xgmi_detail_tests {
             .expect("errors line");
         assert!(err.contains("wafl_ce=7"), "err: {err:?}");
         assert!(err.contains("wafl_ue=1"), "err: {err:?}");
+    }
+
+    #[test]
+    fn missing_counters_render_as_dash() {
+        let tc = Theme::Default.colors();
+        let mut link = mk_link(0, true, 0, 0);
+        link.tx_bytes = None;
+        link.rx_bytes = None;
+        let (port, meta) = mk_row(vec![link]);
+        let lines = build_xgmi_detail_lines(&port, &meta, None, &tc, false, 0);
+        let text: Vec<String> = lines.iter().map(line_text).collect();
+        let row = text
+            .iter()
+            .find(|l| l.contains("0000:15:00.0"))
+            .expect("link row");
+        // Both the TX and RX cells must show "-" (the BDF carries no dash).
+        assert!(row.matches('-').count() >= 2, "row: {row:?}");
     }
 }

--- a/src/xgmi.rs
+++ b/src/xgmi.rs
@@ -342,18 +342,24 @@ fn read_processor_snapshot(
         }
         // Accumulators are indexed by destination GPU; peers beyond the
         // reported entry count carry no counters but still show the link.
-        let (tx_bytes, rx_bytes) = if peer_idx < n {
-            let entry = &metrics.links[peer_idx];
-            (
-                Some(entry.write_kb.wrapping_mul(1024)),
-                Some(entry.read_kb.wrapping_mul(1024)),
-            )
-        } else {
-            (None, None)
+        // The positional mapping is trusted only while the entry's own bdf
+        // is unset (always zero on ROCm 6.4) or agrees with the peer's.
+        let (tx_bytes, rx_bytes) = match metrics.links.get(peer_idx) {
+            Some(entry)
+                if peer_idx < n && (entry.bdf == 0 || Some(entry.bdf) == bdfs[peer_idx]) =>
+            {
+                (
+                    Some(entry.write_kb.wrapping_mul(1024)),
+                    Some(entry.read_kb.wrapping_mul(1024)),
+                )
+            }
+            _ => (None, None),
         };
         total_gbps += speed_gbps.unwrap_or(0.0);
         links.push(XgmiLinkSnapshot {
             link_id: peer_idx as u32,
+            // amdsmi_get_gpu_xgmi_link_status reports DOWN/DISABLE on
+            // working MI300 links, so topo-confirmed peers show as active.
             is_active: true,
             speed_gbps,
             bit_rate_gbps,
@@ -517,6 +523,15 @@ mod tests {
                 assert!(
                     l.speed_gbps.unwrap_or(0.0) > 0.0,
                     "gpu{} link{} has zero speed",
+                    s.gpu_index,
+                    l.link_id
+                );
+                // Guards the positional accumulator mapping: every peer on
+                // this host must carry counters (catches off-by-one in `n`
+                // and bdf-mismatch degradation).
+                assert!(
+                    l.tx_bytes.is_some() && l.rx_bytes.is_some(),
+                    "gpu{} link{} has no accumulator data",
                     s.gpu_index,
                     l.link_id
                 );

--- a/src/xgmi.rs
+++ b/src/xgmi.rs
@@ -1,0 +1,550 @@
+//! XGMI data layer built on top of AMD SMI (`libamd_smi`), compiled only
+//! with the `xgmi` cargo feature. The library is dlopen'd at runtime; when
+//! absent or failing to init, `read_all_xgmi_stats` returns an empty vector.
+
+use std::ffi::CStr;
+use std::io;
+use std::ptr;
+use std::sync::OnceLock;
+
+/// Snapshot of a single XGMI link at one sample.
+#[derive(Clone, Debug)]
+pub struct XgmiLinkSnapshot {
+    /// Peer GPU index (also indexes amdsmi's per-peer accumulators); not
+    /// contiguous since the GPU's own index is skipped.
+    pub link_id: u32,
+    pub is_active: bool,
+    /// Link max bandwidth in Gb/s (e.g. 512 on MI325X). Used for bar scaling.
+    pub speed_gbps: Option<f64>,
+    /// Per-lane bit rate in Gb/s (e.g. 32). Reserved for future column display.
+    #[allow(dead_code)]
+    pub bit_rate_gbps: Option<f64>,
+    /// BDF of the peer GPU on the other end of the link.
+    pub remote_pci_bdf: Option<String>,
+    /// Accumulated bytes written to the link (amdsmi `write` KB * 1024).
+    pub tx_bytes: Option<u64>,
+    /// Accumulated bytes read from the link (amdsmi `read` KB * 1024).
+    pub rx_bytes: Option<u64>,
+}
+
+/// Snapshot of every XGMI link attached to one GPU.
+#[derive(Clone, Debug)]
+pub struct XgmiSnapshot {
+    pub gpu_index: u32,
+    pub gpu_name: String,
+    /// Number of topology-confirmed XGMI peer links.
+    pub link_count: u32,
+    /// Sum of active links' max bandwidth in Gb/s.
+    pub link_gbps: Option<f64>,
+    /// XGMI_WAFL block accumulated ECC counts (per-GPU, not per-link).
+    pub correctable_errors: Option<u64>,
+    pub uncorrectable_errors: Option<u64>,
+    pub links: Vec<XgmiLinkSnapshot>,
+}
+
+impl XgmiSnapshot {
+    /// Count of links currently reported as up.
+    pub fn active_links(&self) -> u32 {
+        self.links.iter().filter(|l| l.is_active).count() as u32
+    }
+}
+
+/// Render an `amdsmi_bdf_t` u64 as "dddd:bb:dd.f" (domain:bus:device.function).
+/// Bit layout (LSB first): function 3 bits, device 5, bus 8, domain 48.
+fn format_bdf(bdf: u64) -> String {
+    let function = bdf & 0x7;
+    let device = (bdf >> 3) & 0x1f;
+    let bus = (bdf >> 8) & 0xff;
+    let domain = (bdf >> 16) & 0xffff_ffff_ffff;
+    format!("{:04x}:{:02x}:{:02x}.{:x}", domain, bus, device, function)
+}
+
+/// Minimal hand-rolled bindings for the amdsmi entry points rdmatop needs.
+/// Layouts are pinned to the ROCm 6.x ABI and guarded by size/offset
+/// assertions below; see amdsmi.h in ROCm for the reference definitions.
+mod ffi {
+    use std::os::raw::{c_char, c_void};
+
+    pub type AmdsmiStatus = u32;
+    pub type SocketHandle = *mut c_void;
+    pub type ProcessorHandle = *mut c_void;
+
+    pub const AMDSMI_STATUS_SUCCESS: AmdsmiStatus = 0;
+    pub const AMDSMI_INIT_AMD_GPUS: u64 = 1 << 1;
+    pub const AMDSMI_MAX_STRING_LENGTH: usize = 256;
+    pub const AMDSMI_MAX_NUM_XGMI_PHYSICAL_LINK: usize = 64;
+    pub const AMDSMI_IOLINK_TYPE_XGMI: u32 = 2;
+    pub const AMDSMI_GPU_BLOCK_XGMI_WAFL: u64 = 0x80;
+
+    /// One entry of `amdsmi_link_metrics_t.links[]`.
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct LinkMetricsEntry {
+        pub bdf: u64,
+        pub bit_rate: u32,      // current link speed in Gb/s
+        pub max_bandwidth: u32, // max link bandwidth in Gb/s
+        pub link_type: u32,     // amdsmi_link_type_t
+        pub read_kb: u64,       // total data received per link (KB)
+        pub write_kb: u64,      // total data transmitted per link (KB)
+        pub reserved: [u64; 2],
+    }
+
+    #[repr(C)]
+    pub struct LinkMetrics {
+        pub num_links: u32,
+        pub links: [LinkMetricsEntry; AMDSMI_MAX_NUM_XGMI_PHYSICAL_LINK],
+        pub reserved: [u64; 7],
+    }
+
+    #[repr(C)]
+    pub struct AsicInfo {
+        pub market_name: [c_char; AMDSMI_MAX_STRING_LENGTH],
+        pub vendor_id: u32,
+        pub vendor_name: [c_char; AMDSMI_MAX_STRING_LENGTH],
+        pub subvendor_id: u32,
+        pub device_id: u64,
+        pub rev_id: u32,
+        pub asic_serial: [c_char; AMDSMI_MAX_STRING_LENGTH],
+        pub oam_id: u32,
+        pub num_of_compute_units: u32,
+        pub target_graphics_version: u64,
+        pub reserved: [u32; 22],
+    }
+
+    #[repr(C)]
+    pub struct ErrorCount {
+        pub correctable_count: u64,
+        pub uncorrectable_count: u64,
+        pub deferred_count: u64,
+        pub reserved: [u64; 5],
+    }
+
+    /// Prefix of `amdsmi_pcie_info_t` (512 bytes total). Only the two leading
+    /// `pcie_static` fields are read; the remainder is opaque padding.
+    #[repr(C)]
+    pub struct PcieInfo {
+        pub max_pcie_width: u16,
+        pub max_pcie_speed: u32, // MT/s at runtime (header comment says GT/s)
+        pub _rest: [u64; 63],
+    }
+
+    // ABI guards: sizes/offsets computed from amdsmi.h (ROCm 6.4.2). A silent
+    // layout drift would corrupt every field after the divergence point.
+    const _: () = assert!(std::mem::size_of::<LinkMetricsEntry>() == 56);
+    const _: () = assert!(std::mem::offset_of!(LinkMetricsEntry, read_kb) == 24);
+    const _: () = assert!(std::mem::size_of::<LinkMetrics>() == 3648);
+    const _: () = assert!(std::mem::offset_of!(LinkMetrics, links) == 8);
+    const _: () = assert!(std::mem::size_of::<AsicInfo>() == 896);
+    const _: () = assert!(std::mem::offset_of!(AsicInfo, device_id) == 520);
+    const _: () = assert!(std::mem::size_of::<ErrorCount>() == 64);
+    const _: () = assert!(std::mem::size_of::<PcieInfo>() == 512);
+    const _: () = assert!(std::mem::offset_of!(PcieInfo, max_pcie_speed) == 4);
+    const _: () = assert!(std::mem::offset_of!(PcieInfo, _rest) == 8);
+}
+
+/// Resolved amdsmi function pointers. `_lib` keeps the dlopen handle alive
+/// for the lifetime of the pointers.
+struct Amdsmi {
+    _lib: libloading::Library,
+    get_socket_handles: unsafe extern "C" fn(*mut u32, *mut ffi::SocketHandle) -> ffi::AmdsmiStatus,
+    get_processor_handles: unsafe extern "C" fn(
+        ffi::SocketHandle,
+        *mut u32,
+        *mut ffi::ProcessorHandle,
+    ) -> ffi::AmdsmiStatus,
+    get_gpu_asic_info:
+        unsafe extern "C" fn(ffi::ProcessorHandle, *mut ffi::AsicInfo) -> ffi::AmdsmiStatus,
+    get_link_metrics:
+        unsafe extern "C" fn(ffi::ProcessorHandle, *mut ffi::LinkMetrics) -> ffi::AmdsmiStatus,
+    get_gpu_device_bdf: unsafe extern "C" fn(ffi::ProcessorHandle, *mut u64) -> ffi::AmdsmiStatus,
+    get_pcie_info:
+        unsafe extern "C" fn(ffi::ProcessorHandle, *mut ffi::PcieInfo) -> ffi::AmdsmiStatus,
+    topo_get_link_type: unsafe extern "C" fn(
+        ffi::ProcessorHandle,
+        ffi::ProcessorHandle,
+        *mut u64,
+        *mut u32,
+    ) -> ffi::AmdsmiStatus,
+    get_gpu_ecc_count:
+        unsafe extern "C" fn(ffi::ProcessorHandle, u64, *mut ffi::ErrorCount) -> ffi::AmdsmiStatus,
+}
+
+/// Library names tried in order: bare sonames first (ld.so search path),
+/// then the conventional ROCm install location.
+const LIB_CANDIDATES: [&str; 3] = [
+    "libamd_smi.so",
+    "libamd_smi.so.25",
+    "/opt/rocm/lib/libamd_smi.so",
+];
+
+impl Amdsmi {
+    fn load() -> Option<Self> {
+        for path in LIB_CANDIDATES {
+            if let Ok(lib) = unsafe { libloading::Library::new(path) } {
+                if let Some(api) = Self::from_lib(lib) {
+                    return Some(api);
+                }
+            }
+        }
+        None
+    }
+
+    fn from_lib(lib: libloading::Library) -> Option<Self> {
+        // Fn pointers are copied out of the Symbol wrappers; they stay valid
+        // because `_lib` is stored alongside them.
+        unsafe {
+            let init: unsafe extern "C" fn(u64) -> ffi::AmdsmiStatus =
+                *lib.get(b"amdsmi_init\0").ok()?;
+            let api = Amdsmi {
+                get_socket_handles: *lib.get(b"amdsmi_get_socket_handles\0").ok()?,
+                get_processor_handles: *lib.get(b"amdsmi_get_processor_handles\0").ok()?,
+                get_gpu_asic_info: *lib.get(b"amdsmi_get_gpu_asic_info\0").ok()?,
+                get_link_metrics: *lib.get(b"amdsmi_get_link_metrics\0").ok()?,
+                get_gpu_device_bdf: *lib.get(b"amdsmi_get_gpu_device_bdf\0").ok()?,
+                get_pcie_info: *lib.get(b"amdsmi_get_pcie_info\0").ok()?,
+                topo_get_link_type: *lib.get(b"amdsmi_topo_get_link_type\0").ok()?,
+                get_gpu_ecc_count: *lib.get(b"amdsmi_get_gpu_ecc_count\0").ok()?,
+                _lib: lib,
+            };
+            if init(ffi::AMDSMI_INIT_AMD_GPUS) != ffi::AMDSMI_STATUS_SUCCESS {
+                return None;
+            }
+            Some(api)
+        }
+    }
+}
+
+/// dlopen + amdsmi_init exactly once per process; amdsmi_shut_down is never
+/// called (process exit tears it down). A failed init is cached as `None`.
+fn instance() -> Option<&'static Amdsmi> {
+    static INSTANCE: OnceLock<Option<Amdsmi>> = OnceLock::new();
+    INSTANCE.get_or_init(Amdsmi::load).as_ref()
+}
+
+/// C out-param wrapper with trailing headroom so a newer libamd_smi whose
+/// struct outgrew our pinned ROCm 6.x layout cannot overrun the allocation.
+#[repr(C)]
+struct Padded<T> {
+    value: T,
+    _headroom: [u8; 4096],
+}
+
+impl<T> Padded<T> {
+    /// All-integer repr(C) PODs only, mirroring the zeroed C-side init.
+    fn zeroed() -> Self {
+        unsafe { std::mem::zeroed() }
+    }
+}
+
+/// Read XGMI statistics for every AMD GPU in the system. Missing library or
+/// zero GPUs yield an empty vector; per-GPU failures skip that GPU and
+/// per-field failures degrade to `None`.
+pub fn read_all_xgmi_stats() -> io::Result<Vec<XgmiSnapshot>> {
+    let api = match instance() {
+        Some(a) => a,
+        None => return Ok(Vec::new()),
+    };
+
+    let handles = enumerate_gpus(api);
+    if handles.is_empty() {
+        return Ok(Vec::new());
+    }
+    let bdfs: Vec<Option<u64>> = handles.iter().map(|&h| read_bdf(api, h)).collect();
+    let names = gpu_names(api, &handles);
+
+    let mut snapshots = Vec::with_capacity(handles.len());
+    for idx in 0..handles.len() {
+        if let Some(snap) = read_processor_snapshot(api, &handles, &bdfs, names, idx) {
+            snapshots.push(snap);
+        }
+    }
+    Ok(snapshots)
+}
+
+/// GPU marketing names, read once and cached by GPU index:
+/// `amdsmi_get_gpu_asic_info` leaks one fd per call on ROCm 6.4.x, so
+/// calling it every refresh exhausts the fd table within minutes.
+fn gpu_names(api: &Amdsmi, handles: &[ffi::ProcessorHandle]) -> &'static [String] {
+    static NAMES: OnceLock<Vec<String>> = OnceLock::new();
+    NAMES.get_or_init(|| {
+        handles
+            .iter()
+            .map(|&h| read_gpu_name(api, h).unwrap_or_default())
+            .collect()
+    })
+}
+
+/// Flatten socket/processor enumeration into one ordered GPU handle list.
+/// This order defines `gpu_index` and matches amdsmi's accumulator indexing.
+fn enumerate_gpus(api: &Amdsmi) -> Vec<ffi::ProcessorHandle> {
+    let mut handles = Vec::new();
+    let mut socket_count: u32 = 0;
+    let rc = unsafe { (api.get_socket_handles)(&mut socket_count, ptr::null_mut()) };
+    if rc != ffi::AMDSMI_STATUS_SUCCESS || socket_count == 0 {
+        return handles;
+    }
+    let mut sockets: Vec<ffi::SocketHandle> = vec![ptr::null_mut(); socket_count as usize];
+    let rc = unsafe { (api.get_socket_handles)(&mut socket_count, sockets.as_mut_ptr()) };
+    if rc != ffi::AMDSMI_STATUS_SUCCESS {
+        return handles;
+    }
+    for &socket in sockets.iter().take(socket_count as usize) {
+        let mut proc_count: u32 = 0;
+        let rc = unsafe { (api.get_processor_handles)(socket, &mut proc_count, ptr::null_mut()) };
+        if rc != ffi::AMDSMI_STATUS_SUCCESS || proc_count == 0 {
+            continue;
+        }
+        let mut procs: Vec<ffi::ProcessorHandle> = vec![ptr::null_mut(); proc_count as usize];
+        let rc =
+            unsafe { (api.get_processor_handles)(socket, &mut proc_count, procs.as_mut_ptr()) };
+        if rc != ffi::AMDSMI_STATUS_SUCCESS {
+            continue;
+        }
+        handles.extend(procs.iter().take(proc_count as usize).copied());
+    }
+    handles
+}
+
+fn read_bdf(api: &Amdsmi, handle: ffi::ProcessorHandle) -> Option<u64> {
+    let mut bdf: u64 = 0;
+    let rc = unsafe { (api.get_gpu_device_bdf)(handle, &mut bdf) };
+    (rc == ffi::AMDSMI_STATUS_SUCCESS).then_some(bdf)
+}
+
+/// Build one GPU's snapshot. A "link" is an XGMI peer connection: topology
+/// says which destination GPUs are XGMI-reachable, link_metrics supplies the
+/// per-peer accumulators (indexed by destination GPU), pcie_info the speed.
+fn read_processor_snapshot(
+    api: &Amdsmi,
+    handles: &[ffi::ProcessorHandle],
+    bdfs: &[Option<u64>],
+    names: &[String],
+    idx: usize,
+) -> Option<XgmiSnapshot> {
+    let handle = handles[idx];
+    let mut metrics: Padded<ffi::LinkMetrics> = Padded::zeroed();
+    let rc = unsafe { (api.get_link_metrics)(handle, &mut metrics.value) };
+    if rc != ffi::AMDSMI_STATUS_SUCCESS {
+        return None;
+    }
+    let metrics = &metrics.value;
+
+    let gpu_name = names.get(idx).cloned().unwrap_or_default();
+    let (bit_rate_gbps, speed_gbps) = read_link_speed(api, handle);
+    let (correctable_errors, uncorrectable_errors) = read_wafl_errors(api, handle);
+
+    let n = (metrics.num_links as usize).min(ffi::AMDSMI_MAX_NUM_XGMI_PHYSICAL_LINK);
+    let mut links = Vec::new();
+    let mut total_gbps = 0.0;
+    for (peer_idx, &peer) in handles.iter().enumerate() {
+        if peer_idx == idx || !is_xgmi_peer(api, handle, peer) {
+            continue;
+        }
+        // Accumulators are indexed by destination GPU; peers beyond the
+        // reported entry count carry no counters but still show the link.
+        let (tx_bytes, rx_bytes) = if peer_idx < n {
+            let entry = &metrics.links[peer_idx];
+            (
+                Some(entry.write_kb.wrapping_mul(1024)),
+                Some(entry.read_kb.wrapping_mul(1024)),
+            )
+        } else {
+            (None, None)
+        };
+        total_gbps += speed_gbps.unwrap_or(0.0);
+        links.push(XgmiLinkSnapshot {
+            link_id: peer_idx as u32,
+            is_active: true,
+            speed_gbps,
+            bit_rate_gbps,
+            remote_pci_bdf: bdfs[peer_idx].map(format_bdf),
+            tx_bytes,
+            rx_bytes,
+        });
+    }
+
+    // A GPU with no XGMI peers (e.g. consumer card) contributes no row.
+    if links.is_empty() {
+        return None;
+    }
+
+    Some(XgmiSnapshot {
+        gpu_index: idx as u32,
+        gpu_name,
+        link_count: links.len() as u32,
+        link_gbps: (total_gbps > 0.0).then_some(total_gbps),
+        correctable_errors,
+        uncorrectable_errors,
+        links,
+    })
+}
+
+/// True when topology reports an XGMI io-link between the two GPUs.
+fn is_xgmi_peer(api: &Amdsmi, src: ffi::ProcessorHandle, dst: ffi::ProcessorHandle) -> bool {
+    let mut hops: u64 = 0;
+    let mut link_type: u32 = 0;
+    let rc = unsafe { (api.topo_get_link_type)(src, dst, &mut hops, &mut link_type) };
+    rc == ffi::AMDSMI_STATUS_SUCCESS && link_type == ffi::AMDSMI_IOLINK_TYPE_XGMI
+}
+
+/// Per-link (bit_rate, bandwidth) in Gb/s from PCIe static info, mirroring
+/// amd-smi: bit_rate = max_pcie_speed/1000, bandwidth = bit_rate * width.
+fn read_link_speed(api: &Amdsmi, handle: ffi::ProcessorHandle) -> (Option<f64>, Option<f64>) {
+    let mut info: Padded<ffi::PcieInfo> = Padded::zeroed();
+    let rc = unsafe { (api.get_pcie_info)(handle, &mut info.value) };
+    if rc != ffi::AMDSMI_STATUS_SUCCESS || info.value.max_pcie_speed == 0 {
+        return (None, None);
+    }
+    let info = &info.value;
+    // Runtime value is MT/s (e.g. 32000); tolerate GT/s (e.g. 32) as-is.
+    let bit_rate = if info.max_pcie_speed >= 1000 {
+        info.max_pcie_speed as f64 / 1000.0
+    } else {
+        info.max_pcie_speed as f64
+    };
+    let bandwidth = (info.max_pcie_width > 0).then_some(bit_rate * info.max_pcie_width as f64);
+    (Some(bit_rate), bandwidth)
+}
+
+fn read_gpu_name(api: &Amdsmi, handle: ffi::ProcessorHandle) -> Option<String> {
+    let mut info: Padded<ffi::AsicInfo> = Padded::zeroed();
+    let rc = unsafe { (api.get_gpu_asic_info)(handle, &mut info.value) };
+    if rc != ffi::AMDSMI_STATUS_SUCCESS {
+        return None;
+    }
+    let info = &mut info.value;
+    // Ensure NUL-termination even if amdsmi fills the buffer completely.
+    info.market_name[ffi::AMDSMI_MAX_STRING_LENGTH - 1] = 0;
+    let name = unsafe { CStr::from_ptr(info.market_name.as_ptr() as *const std::os::raw::c_char) };
+    let name = name.to_string_lossy().trim().to_string();
+    (!name.is_empty()).then_some(name)
+}
+
+fn read_wafl_errors(api: &Amdsmi, handle: ffi::ProcessorHandle) -> (Option<u64>, Option<u64>) {
+    let mut ec: Padded<ffi::ErrorCount> = Padded::zeroed();
+    let rc =
+        unsafe { (api.get_gpu_ecc_count)(handle, ffi::AMDSMI_GPU_BLOCK_XGMI_WAFL, &mut ec.value) };
+    if rc != ffi::AMDSMI_STATUS_SUCCESS {
+        return (None, None);
+    }
+    (
+        Some(ec.value.correctable_count),
+        Some(ec.value.uncorrectable_count),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn link(id: u32, active: bool) -> XgmiLinkSnapshot {
+        XgmiLinkSnapshot {
+            link_id: id,
+            is_active: active,
+            speed_gbps: None,
+            bit_rate_gbps: None,
+            remote_pci_bdf: None,
+            tx_bytes: None,
+            rx_bytes: None,
+        }
+    }
+
+    #[test]
+    fn active_links_counts_active_only() {
+        let snap = XgmiSnapshot {
+            gpu_index: 0,
+            gpu_name: "test".to_string(),
+            link_count: 3,
+            link_gbps: None,
+            correctable_errors: None,
+            uncorrectable_errors: None,
+            links: vec![link(0, true), link(1, false), link(2, true)],
+        };
+        assert_eq!(snap.active_links(), 2);
+    }
+
+    #[test]
+    fn active_links_no_links() {
+        let snap = XgmiSnapshot {
+            gpu_index: 0,
+            gpu_name: "test".to_string(),
+            link_count: 0,
+            link_gbps: None,
+            correctable_errors: None,
+            uncorrectable_errors: None,
+            links: Vec::new(),
+        };
+        assert_eq!(snap.active_links(), 0);
+    }
+
+    #[test]
+    fn format_bdf_matches_lspci_form() {
+        // 0000:05:00.0 -> domain 0, bus 5, device 0, function 0
+        assert_eq!(format_bdf(0x0000_0000_0000_0500), "0000:05:00.0");
+        // 0000:f5:00.0 (amd1 GPU7)
+        assert_eq!(format_bdf(0x0000_0000_0000_f500), "0000:f5:00.0");
+        // function/device bits: bus 0x65, device 0x1f, function 7
+        // bdf = domain<<16 | bus<<8 | device<<3 | function
+        assert_eq!(format_bdf((0x65 << 8) | (0x1f << 3) | 0x7), "0000:65:1f.7");
+    }
+
+    /// Hardware smoke test: run with `cargo test --features xgmi -- --ignored`
+    /// on a machine with AMD GPUs.
+    #[test]
+    #[ignore]
+    fn smoke_read_all_xgmi_stats() {
+        let snaps = read_all_xgmi_stats().expect("io error");
+        assert!(!snaps.is_empty(), "expected XGMI-capable GPUs on this host");
+        assert!(
+            snaps.iter().any(|s| s.link_count == 7),
+            "expected at least one GPU with 7 XGMI links on amd1"
+        );
+        for s in &snaps {
+            assert!(s.link_count > 0);
+            assert!(
+                s.active_links() > 0,
+                "gpu{} has no active links",
+                s.gpu_index
+            );
+            for l in &s.links {
+                let bdf = l.remote_pci_bdf.as_deref().unwrap_or("<none>");
+                assert!(
+                    l.remote_pci_bdf.is_some() && bdf != "0000:00:00.0",
+                    "gpu{} link{} has null BDF",
+                    s.gpu_index,
+                    l.link_id
+                );
+                assert!(
+                    l.speed_gbps.unwrap_or(0.0) > 0.0,
+                    "gpu{} link{} has zero speed",
+                    s.gpu_index,
+                    l.link_id
+                );
+            }
+        }
+        // Print compact dump of gpu0's snapshot for eyeballing.
+        if let Some(s) = snaps.first() {
+            let fl = s.links.first();
+            eprintln!(
+                "gpu0 name={:?} link_gbps={:?} first_link={:?}",
+                s.gpu_name, s.link_gbps, fl
+            );
+        }
+
+        // Regression check: repeated polling must not leak fds (the TUI
+        // calls this every refresh; amdsmi_get_gpu_asic_info leaks on
+        // ROCm 6.4.x when called per refresh, so names are cached).
+        let count_fds = || std::fs::read_dir("/proc/self/fd").unwrap().count();
+        let before = count_fds();
+        for _ in 0..100 {
+            read_all_xgmi_stats().expect("io error");
+        }
+        let after = count_fds();
+        assert!(
+            after <= before + 2,
+            "fd leak: {} -> {} after 100 polls",
+            before,
+            after
+        );
+    }
+}


### PR DESCRIPTION
## Purpose

Add AMD XGMI monitoring behind an opt-in `xgmi` cargo feature, mirroring the NVLink support from #26. Each AMD GPU shows as an `amdgpu<N>` row with aggregate XGMI TX/RX, plus a detail pane (per-link state, speed, rates, peer GPU BDF, XGMI_WAFL ECC counters).

## Test Plan

Launch the following script to verify xgmi traffic can be observed.

```python
import argparse
import time

import torch
import torch.distributed as dist


def main():
    p = argparse.ArgumentParser()
    p.add_argument("--mb", type=int, default=256, help="per-rank shard size in MiB")
    p.add_argument("--secs", type=float, default=60, help="run duration in seconds")
    args = p.parse_args()

    dist.init_process_group("nccl")  # RCCL on ROCm
    rank = dist.get_rank()
    world = dist.get_world_size()
    torch.cuda.set_device(rank % torch.cuda.device_count())

    n = args.mb * (1 << 20) // 2  # fp16 elements
    x = torch.randn(n, dtype=torch.float16, device="cuda")
    out = [torch.empty_like(x) for _ in range(world)]

    for _ in range(3):  # warmup
        dist.all_gather(out, x)
    torch.cuda.synchronize()

    shard_bytes = x.numel() * x.element_size()
    t0 = time.time()
    iters = 0
    while time.time() - t0 < args.secs:
        for _ in range(10):
            dist.all_gather(out, x)
            iters += 1
        torch.cuda.synchronize()
        if rank == 0:
            el = time.time() - t0
            # ring all-gather: each GPU transmits (world-1) shards per iter
            gbps = iters * shard_bytes * (world - 1) * 8 / 1e9 / el
            print(f"{el:6.1f}s  {iters:5d} iters  ~{gbps:7.1f} Gbps TX/GPU", flush=True)

    dist.destroy_process_group()


if __name__ == "__main__":
    main()
```
command

```
torchrun --nproc_per_node=8 ~/changning/allgather_bench.py --mb 256 --secs 60
```

## Test Result

<img width="1074" height="536" alt="Screenshot 2026-07-05 at 9 22 15 AM" src="https://github.com/user-attachments/assets/ef305b35-858b-4811-9328-d2b99fcb0f89" />