### PR TITLE
perf(xgmi): cache static link speeds, halving per-refresh cost

### DIFF
--- a/src/xgmi.rs
+++ b/src/xgmi.rs
@@ -251,10 +251,11 @@ pub fn read_all_xgmi_stats() -> io::Result<Vec<XgmiSnapshot>> {
     }
     let bdfs: Vec<Option<u64>> = handles.iter().map(|&h| read_bdf(api, h)).collect();
     let names = gpu_names(api, &handles);
+    let speeds = link_speeds(api, &handles);
 
     let mut snapshots = Vec::with_capacity(handles.len());
     for idx in 0..handles.len() {
-        if let Some(snap) = read_processor_snapshot(api, &handles, &bdfs, names, idx) {
+        if let Some(snap) = read_processor_snapshot(api, &handles, &bdfs, names, speeds, idx) {
             snapshots.push(snap);
         }
     }
@@ -272,6 +273,17 @@ fn gpu_names(api: &Amdsmi, handles: &[ffi::ProcessorHandle]) -> &'static [String
             .map(|&h| read_gpu_name(api, h).unwrap_or_default())
             .collect()
     })
+}
+
+/// Per-GPU (bit_rate, bandwidth) Gb/s, read once and cached by GPU index:
+/// link speed is static and `amdsmi_get_pcie_info` costs ~0.5 ms per call —
+/// roughly half of the whole refresh when polled for every GPU each second.
+fn link_speeds(
+    api: &Amdsmi,
+    handles: &[ffi::ProcessorHandle],
+) -> &'static [(Option<f64>, Option<f64>)] {
+    static SPEEDS: OnceLock<Vec<(Option<f64>, Option<f64>)>> = OnceLock::new();
+    SPEEDS.get_or_init(|| handles.iter().map(|&h| read_link_speed(api, h)).collect())
 }
 
 /// Flatten socket/processor enumeration into one ordered GPU handle list.
@@ -319,6 +331,7 @@ fn read_processor_snapshot(
     handles: &[ffi::ProcessorHandle],
     bdfs: &[Option<u64>],
     names: &[String],
+    speeds: &[(Option<f64>, Option<f64>)],
     idx: usize,
 ) -> Option<XgmiSnapshot> {
     let handle = handles[idx];
@@ -330,7 +343,7 @@ fn read_processor_snapshot(
     let metrics = &metrics.value;
 
     let gpu_name = names.get(idx).cloned().unwrap_or_default();
-    let (bit_rate_gbps, speed_gbps) = read_link_speed(api, handle);
+    let (bit_rate_gbps, speed_gbps) = speeds.get(idx).copied().unwrap_or((None, None));
     let (correctable_errors, uncorrectable_errors) = read_wafl_errors(api, handle);
 
     let n = (metrics.num_links as usize).min(ffi::AMDSMI_MAX_NUM_XGMI_PHYSICAL_LINK);

--- a/src/xgmi.rs
+++ b/src/xgmi.rs
@@ -5,7 +5,7 @@
 use std::ffi::CStr;
 use std::io;
 use std::ptr;
-use std::sync::OnceLock;
+use std::sync::{Mutex, OnceLock};
 
 /// Snapshot of a single XGMI link at one sample.
 #[derive(Clone, Debug)]
@@ -255,7 +255,7 @@ pub fn read_all_xgmi_stats() -> io::Result<Vec<XgmiSnapshot>> {
 
     let mut snapshots = Vec::with_capacity(handles.len());
     for idx in 0..handles.len() {
-        if let Some(snap) = read_processor_snapshot(api, &handles, &bdfs, names, speeds, idx) {
+        if let Some(snap) = read_processor_snapshot(api, &handles, &bdfs, names, &speeds, idx) {
             snapshots.push(snap);
         }
     }
@@ -275,15 +275,33 @@ fn gpu_names(api: &Amdsmi, handles: &[ffi::ProcessorHandle]) -> &'static [String
     })
 }
 
-/// Per-GPU (bit_rate, bandwidth) Gb/s, read once and cached by GPU index:
-/// link speed is static and `amdsmi_get_pcie_info` costs ~0.5 ms per call —
-/// roughly half of the whole refresh when polled for every GPU each second.
-fn link_speeds(
-    api: &Amdsmi,
-    handles: &[ffi::ProcessorHandle],
-) -> &'static [(Option<f64>, Option<f64>)] {
-    static SPEEDS: OnceLock<Vec<(Option<f64>, Option<f64>)>> = OnceLock::new();
-    SPEEDS.get_or_init(|| handles.iter().map(|&h| read_link_speed(api, h)).collect())
+/// Per-link (bit_rate, bandwidth) in Gb/s from PCIe static info.
+type LinkSpeed = (Option<f64>, Option<f64>);
+
+/// Per-GPU link speeds. Link speed is static and `amdsmi_get_pcie_info`
+/// costs ~0.5 ms (two SMU round-trips), so successful reads are cached by
+/// GPU index; failed reads retry on the next poll rather than degrading
+/// speed reporting for the process lifetime.
+fn link_speeds(api: &Amdsmi, handles: &[ffi::ProcessorHandle]) -> Vec<LinkSpeed> {
+    static CACHE: Mutex<Vec<Option<LinkSpeed>>> = Mutex::new(Vec::new());
+    let mut cache = CACHE.lock().unwrap_or_else(|e| e.into_inner());
+    if cache.len() < handles.len() {
+        cache.resize(handles.len(), None);
+    }
+    handles
+        .iter()
+        .zip(cache.iter_mut())
+        .map(|(&handle, slot)| match slot {
+            Some(speed) => *speed,
+            None => {
+                let speed = read_link_speed(api, handle);
+                if speed != (None, None) {
+                    *slot = Some(speed);
+                }
+                speed
+            }
+        })
+        .collect()
 }
 
 /// Flatten socket/processor enumeration into one ordered GPU handle list.
@@ -331,7 +349,7 @@ fn read_processor_snapshot(
     handles: &[ffi::ProcessorHandle],
     bdfs: &[Option<u64>],
     names: &[String],
-    speeds: &[(Option<f64>, Option<f64>)],
+    speeds: &[LinkSpeed],
     idx: usize,
 ) -> Option<XgmiSnapshot> {
     let handle = handles[idx];
@@ -408,7 +426,7 @@ fn is_xgmi_peer(api: &Amdsmi, src: ffi::ProcessorHandle, dst: ffi::ProcessorHand
 
 /// Per-link (bit_rate, bandwidth) in Gb/s from PCIe static info, mirroring
 /// amd-smi: bit_rate = max_pcie_speed/1000, bandwidth = bit_rate * width.
-fn read_link_speed(api: &Amdsmi, handle: ffi::ProcessorHandle) -> (Option<f64>, Option<f64>) {
+fn read_link_speed(api: &Amdsmi, handle: ffi::ProcessorHandle) -> LinkSpeed {
     let mut info: Padded<ffi::PcieInfo> = Padded::zeroed();
     let rc = unsafe { (api.get_pcie_info)(handle, &mut info.value) };
     if rc != ffi::AMDSMI_STATUS_SUCCESS || info.value.max_pcie_speed == 0 {


### PR DESCRIPTION
## Purpose

Halve XGMI per-refresh sampling cost by caching static link speeds. `amdsmi_get_pcie_info` costs ~0.5 ms per call (it re-reads `gpu_metrics` twice per call — two SMU firmware round-trips) and was polled for every GPU every refresh, yet PCIe max speed/width are fixed at link training and never change. Read once into a `OnceLock` (same pattern as the existing GPU-name cache) and look up per poll.

## Test Plan

A/B benchmark on 8× MI325X (ROCm 6.4.2) of the exact per-refresh amdsmi call sequence, 5 runs × 100 polls each; full test suite + hardware smoke test.

## Test Result

OLD (pcie_info every poll):  9.01  9.00  9.01  9.00  9.00  ms/poll
NEW (pcie_info cached):      4.70  4.70  4.67  4.69  4.67  ms/poll   (-48%)

## Checklist

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes
- [x] Tested on RDMA-capable hardware (or explained why not in the Test Plan)
- [ ] Docs/README updated if behavior or flags changed
