### PR TITLE
Add ASCII fallback for non-UTF-8 terminals

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ fn run_tui() -> io::Result<()> {
     crossterm::terminal::enable_raw_mode()?;
     let mut stdout = io::stdout();
     crossterm::execute!(stdout, crossterm::terminal::EnterAlternateScreen)?;
+    tui::glyphs::detect();
 
     let backend = ratatui::backend::CrosstermBackend::new(stdout);
     let mut terminal = ratatui::Terminal::new(backend)?;

--- a/src/tui/glyphs.rs
+++ b/src/tui/glyphs.rs
@@ -1,0 +1,152 @@
+//! ASCII fallback for terminals whose locale isn't UTF-8 (e.g. LC_ALL=C, or
+//! tmux without `-u`), where box-drawing/block glyphs render as garbage.
+//! We build the UI in Unicode as usual and transliterate at the emit points.
+
+use ratatui::symbols;
+use ratatui::widgets::{Scrollbar, ScrollbarOrientation};
+use std::borrow::Cow;
+use std::sync::OnceLock;
+
+/// Whether we can safely draw UTF-8 glyphs. Cached at first call.
+///
+/// Locale-driven, like htop: a UTF-8 `LC_*`/`LANG` gets blocks, anything else
+/// (C/POSIX) gets ASCII. `RDMATOP_UNICODE=0|1` forces it either way. Note that
+/// `tmux -u` alone does NOT change the locale, so to get blocks under tmux set
+/// a UTF-8 locale (e.g. `LC_ALL=C.UTF-8`) — which also renders without `-u`.
+pub fn unicode() -> bool {
+    static U: OnceLock<bool> = OnceLock::new();
+    *U.get_or_init(|| {
+        if let Ok(v) = std::env::var("RDMATOP_UNICODE") {
+            let v = v.to_ascii_lowercase();
+            return !matches!(v.as_str(), "" | "0" | "false" | "no");
+        }
+        // POSIX precedence: LC_ALL > LC_CTYPE > LANG; first non-empty decides.
+        for k in ["LC_ALL", "LC_CTYPE", "LANG"] {
+            if let Ok(v) = std::env::var(k) {
+                if !v.is_empty() {
+                    let v = v.to_ascii_uppercase();
+                    return v.contains("UTF-8") || v.contains("UTF8");
+                }
+            }
+        }
+        false
+    })
+}
+
+/// Map a Unicode glyph to its closest ASCII stand-in.
+fn ascii(c: char) -> Option<&'static str> {
+    Some(match c {
+        '│' | '▏' | '▐' => "|",
+        '─' => "-",
+        '↑' | '▲' => "^",
+        '↓' | '▼' => "v",
+        '←' | '◀' => "<",
+        '→' | '▶' => ">",
+        '●' => "*",
+        '▬' => "=",
+        '±' => "+-",
+        '…' => "...",
+        '█' | '▇' => "#",
+        '░' => "-",
+        '▆' | '▅' => "*",
+        '▄' | '▃' => "+",
+        '▂' => ".",
+        '▁' => "_",
+        _ => return None,
+    })
+}
+
+/// Transliterate a string to ASCII when the terminal can't do UTF-8.
+pub fn tr(s: &str) -> Cow<'_, str> {
+    if unicode() || s.is_ascii() {
+        return Cow::Borrowed(s);
+    }
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match ascii(c) {
+            Some(a) => out.push_str(a),
+            None => out.push(c),
+        }
+    }
+    Cow::Owned(out)
+}
+
+/// Throughput meter fill/empty chars: solid block over faint shade in UTF-8,
+/// htop-style pipe over blank in ASCII.
+pub fn meter() -> (char, char) {
+    if unicode() {
+        ('█', '░')
+    } else {
+        ('|', ' ')
+    }
+}
+
+/// Selection cursor for tables (`highlight_symbol`).
+pub fn cursor() -> &'static str {
+    if unicode() {
+        "▶ "
+    } else {
+        "> "
+    }
+}
+
+/// Border set for `Block`s; ASCII box when the locale isn't UTF-8.
+pub fn border() -> symbols::border::Set<'static> {
+    if unicode() {
+        symbols::border::PLAIN
+    } else {
+        symbols::border::Set {
+            top_left: "+",
+            top_right: "+",
+            bottom_left: "+",
+            bottom_right: "+",
+            vertical_left: "|",
+            vertical_right: "|",
+            horizontal_top: "-",
+            horizontal_bottom: "-",
+        }
+    }
+}
+
+pub fn v_scrollbar() -> Scrollbar<'static> {
+    let (thumb, track, up, down) = if unicode() {
+        ("▐", "│", "▲", "▼")
+    } else {
+        ("#", "|", "^", "v")
+    };
+    Scrollbar::new(ScrollbarOrientation::VerticalRight)
+        .thumb_symbol(thumb)
+        .track_symbol(Some(track))
+        .begin_symbol(Some(up))
+        .end_symbol(Some(down))
+}
+
+pub fn h_scrollbar() -> Scrollbar<'static> {
+    let (thumb, track, left, right) = if unicode() {
+        ("▬", "─", "◀", "▶")
+    } else {
+        ("=", "-", "<", ">")
+    };
+    Scrollbar::new(ScrollbarOrientation::HorizontalBottom)
+        .thumb_symbol(thumb)
+        .track_symbol(Some(track))
+        .begin_symbol(Some(left))
+        .end_symbol(Some(right))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ascii;
+
+    #[test]
+    fn ascii_map_covers_ui_glyphs() {
+        // Every glyph the UI emits must have an ASCII stand-in, and none map
+        // back to a multibyte char.
+        for c in ['│', '─', '↑', '↓', '←', '→', '●', '▏', '▐', '▲', '▼', '◀',
+            '▶', '▬', '±', '…', '█', '▇', '▆', '▅', '▄', '▃', '▂', '▁', '░']
+        {
+            let a = ascii(c).unwrap_or_else(|| panic!("no ascii for {c:?}"));
+            assert!(a.is_ascii(), "{c:?} -> {a:?} is not ascii");
+        }
+    }
+}

--- a/src/tui/glyphs.rs
+++ b/src/tui/glyphs.rs
@@ -19,9 +19,13 @@ pub fn unicode() -> bool {
 /// raw mode with the alternate screen active. Inside tmux we trust its client
 /// flag; otherwise we probe the terminal, then fall back to the locale.
 pub fn detect() {
-    let ok = tmux_utf8() // authoritative inside tmux
-        .or_else(probe) // else ask the real terminal
-        .unwrap_or_else(locale_utf8);
+    // The probe is fooled inside tmux (see tmux_utf8), so when the tmux
+    // query itself fails we must fall back to the locale, never the probe.
+    let ok = if std::env::var_os("TMUX").is_some() {
+        tmux_utf8().unwrap_or_else(locale_utf8)
+    } else {
+        probe().unwrap_or_else(locale_utf8)
+    };
     let _ = UNICODE.set(ok);
 }
 
@@ -31,11 +35,27 @@ pub fn detect() {
 /// `#{client_utf8}` is the only signal that reflects what reaches the terminal.
 /// `None` when not under tmux, or no client is attached to answer.
 fn tmux_utf8() -> Option<bool> {
+    use std::process::{Command, Stdio};
     std::env::var_os("TMUX")?;
-    let out = std::process::Command::new("tmux")
+    let mut child = Command::new("tmux")
         .args(["display-message", "-p", "#{client_utf8}"])
-        .output()
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
         .ok()?;
+    // Raw mode already disabled Ctrl-C, so a wedged tmux server must not
+    // block startup forever: kill the query if it outlives the deadline.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_millis(500);
+    while child.try_wait().ok()?.is_none() {
+        if std::time::Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            return None;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+    let out = child.wait_with_output().ok()?;
     match out.stdout.first().copied()? {
         b'1' => Some(true),
         b'0' => Some(false),

--- a/src/tui/glyphs.rs
+++ b/src/tui/glyphs.rs
@@ -1,36 +1,79 @@
-//! ASCII fallback for terminals whose locale isn't UTF-8 (e.g. LC_ALL=C, or
-//! tmux without `-u`), where box-drawing/block glyphs render as garbage.
-//! We build the UI in Unicode as usual and transliterate at the emit points.
+//! ASCII fallback for terminals that can't render UTF-8, where box-drawing and
+//! block glyphs come out as garbage. We probe the terminal at startup (see
+//! [`detect`]) and build the UI in Unicode or ASCII accordingly.
 
 use ratatui::symbols;
 use ratatui::widgets::{Scrollbar, ScrollbarOrientation};
 use std::borrow::Cow;
+use std::io::Write;
 use std::sync::OnceLock;
 
-/// Whether we can safely draw UTF-8 glyphs. Cached at first call.
-///
-/// Locale-driven, like htop: a UTF-8 `LC_*`/`LANG` gets blocks, anything else
-/// (C/POSIX) gets ASCII. `RDMATOP_UNICODE=0|1` forces it either way. Note that
-/// `tmux -u` alone does NOT change the locale, so to get blocks under tmux set
-/// a UTF-8 locale (e.g. `LC_ALL=C.UTF-8`) — which also renders without `-u`.
+static UNICODE: OnceLock<bool> = OnceLock::new();
+
+/// Whether we can safely draw UTF-8 glyphs. Cached after [`detect`].
 pub fn unicode() -> bool {
-    static U: OnceLock<bool> = OnceLock::new();
-    *U.get_or_init(|| {
-        if let Ok(v) = std::env::var("RDMATOP_UNICODE") {
-            let v = v.to_ascii_lowercase();
-            return !matches!(v.as_str(), "" | "0" | "false" | "no");
-        }
-        // POSIX precedence: LC_ALL > LC_CTYPE > LANG; first non-empty decides.
-        for k in ["LC_ALL", "LC_CTYPE", "LANG"] {
-            if let Ok(v) = std::env::var(k) {
-                if !v.is_empty() {
-                    let v = v.to_ascii_uppercase();
-                    return v.contains("UTF-8") || v.contains("UTF8");
-                }
+    *UNICODE.get_or_init(locale_utf8)
+}
+
+/// Decide UTF-8 support from the live terminal, once, at startup. Must run in
+/// raw mode with the alternate screen active. Inside tmux we trust its client
+/// flag; otherwise we probe the terminal, then fall back to the locale.
+pub fn detect() {
+    let ok = tmux_utf8() // authoritative inside tmux
+        .or_else(probe) // else ask the real terminal
+        .unwrap_or_else(locale_utf8);
+    let _ = UNICODE.set(ok);
+}
+
+/// Whether tmux will actually render UTF-8. The cursor probe is fooled under
+/// tmux: its grid always decodes UTF-8, so the cursor advances as if UTF-8 even
+/// when the client (non-UTF-8 locale, no `-u`) will strip the bytes to garbage.
+/// `#{client_utf8}` is the only signal that reflects what reaches the terminal.
+/// `None` when not under tmux, or no client is attached to answer.
+fn tmux_utf8() -> Option<bool> {
+    std::env::var_os("TMUX")?;
+    let out = std::process::Command::new("tmux")
+        .args(["display-message", "-p", "#{client_utf8}"])
+        .output()
+        .ok()?;
+    match out.stdout.first().copied()? {
+        b'1' => Some(true),
+        b'0' => Some(false),
+        _ => None,
+    }
+}
+
+/// Print a 1-column multibyte glyph and see how far the cursor moved: 1 column
+/// means the terminal decoded UTF-8, more means it counted raw bytes.
+fn probe() -> Option<bool> {
+    use crossterm::{cursor, queue, terminal};
+    let mut out = std::io::stdout();
+    queue!(out, cursor::MoveTo(0, 0)).ok()?;
+    write!(out, "\u{2588}").ok()?; // █: 3 UTF-8 bytes, 1 display column
+    out.flush().ok()?;
+    let (col, _) = cursor::position().ok()?;
+    queue!(
+        out,
+        cursor::MoveTo(0, 0),
+        terminal::Clear(terminal::ClearType::All)
+    )
+    .ok()?;
+    out.flush().ok()?;
+    Some(col == 1)
+}
+
+/// Locale fallback, like htop: a UTF-8 `LC_*`/`LANG` gets blocks, else ASCII.
+fn locale_utf8() -> bool {
+    // POSIX precedence: LC_ALL > LC_CTYPE > LANG; first non-empty decides.
+    for k in ["LC_ALL", "LC_CTYPE", "LANG"] {
+        if let Ok(v) = std::env::var(k) {
+            if !v.is_empty() {
+                let v = v.to_ascii_uppercase();
+                return v.contains("UTF-8") || v.contains("UTF8");
             }
         }
-        false
-    })
+    }
+    false
 }
 
 /// Map a Unicode glyph to its closest ASCII stand-in.
@@ -142,9 +185,10 @@ mod tests {
     fn ascii_map_covers_ui_glyphs() {
         // Every glyph the UI emits must have an ASCII stand-in, and none map
         // back to a multibyte char.
-        for c in ['│', '─', '↑', '↓', '←', '→', '●', '▏', '▐', '▲', '▼', '◀',
-            '▶', '▬', '±', '…', '█', '▇', '▆', '▅', '▄', '▃', '▂', '▁', '░']
-        {
+        for c in [
+            '│', '─', '↑', '↓', '←', '→', '●', '▏', '▐', '▲', '▼', '◀', '▶', '▬', '±', '…', '█',
+            '▇', '▆', '▅', '▄', '▃', '▂', '▁', '░',
+        ] {
             let a = ascii(c).unwrap_or_else(|| panic!("no ascii for {c:?}"));
             assert!(a.is_ascii(), "{c:?} -> {a:?} is not ascii");
         }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1,4 +1,5 @@
 pub mod app;
 pub mod events;
+pub mod glyphs;
 pub mod theme;
 pub mod ui;

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -2,9 +2,7 @@ use ratatui::{
     layout::{Constraint, Direction, Layout, Margin, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{
-        Block, Borders, Cell, Clear, Paragraph, Row, ScrollbarState, Table, TableState,
-    },
+    widgets::{Block, Borders, Cell, Clear, Paragraph, Row, ScrollbarState, Table, TableState},
     Frame,
 };
 
@@ -427,7 +425,7 @@ fn draw_gpu_table(frame: &mut Frame, app: &mut App, area: Rect, tc: &ThemeColors
         .block(
             Block::default()
                 .borders(Borders::ALL)
-        .border_set(super::glyphs::border())
+                .border_set(super::glyphs::border())
                 .border_style(Style::default().fg(tc.border))
                 .title(title)
                 .title_style(Style::default().fg(tc.accent)),
@@ -562,7 +560,7 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect, tc: &ThemeColors) {
         .block(
             Block::default()
                 .borders(Borders::ALL)
-        .border_set(super::glyphs::border())
+                .border_set(super::glyphs::border())
                 .border_style(Style::default().fg(tc.border))
                 .title(title)
                 .title_style(Style::default().fg(tc.accent)),
@@ -626,19 +624,23 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect, tc: &ThemeColors) {
 }
 
 fn sparkline_str(data: &[f64], width: usize) -> String {
-    const BARS: &[char] = &[' ', '▁', '▂', '▃', '▄', '▅', '▆', '▇', '█'];
+    // Height ramps by index 0..8; ASCII keeps the graph shape without a
+    // mushy underline (idle reads as '.', not '_') in non-UTF-8 locales.
+    const U: &[char] = &[' ', '▁', '▂', '▃', '▄', '▅', '▆', '▇', '█'];
+    const A: &[char] = &[' ', '.', '.', ':', ':', '=', '=', '#', '#'];
+    let bars = if super::glyphs::unicode() { U } else { A };
     let max = data.iter().cloned().fold(0.0f64, f64::max).max(0.01);
     let start = data.len().saturating_sub(width);
     let mut s = String::with_capacity(width);
     for &v in &data[start..] {
         let idx = ((v / max) * 8.0).round() as usize;
-        s.push(BARS[idx.min(8)]);
+        s.push(bars[idx.min(8)]);
     }
     // Pad if not enough data
     while s.chars().count() < width {
         s.insert(0, ' ');
     }
-    super::glyphs::tr(&s).into_owned()
+    s
 }
 
 fn build_detail_lines(
@@ -1030,7 +1032,7 @@ fn draw_detail(frame: &mut Frame, app: &mut App, area: Rect, tc: &ThemeColors) {
             frame.render_widget(
                 Block::default()
                     .borders(Borders::ALL)
-        .border_set(super::glyphs::border())
+                    .border_set(super::glyphs::border())
                     .border_style(Style::default().fg(tc.border))
                     .title(" Detail "),
                 area,

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -3,8 +3,7 @@ use ratatui::{
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{
-        Block, Borders, Cell, Clear, Paragraph, Row, Scrollbar, ScrollbarOrientation,
-        ScrollbarState, Table, TableState,
+        Block, Borders, Cell, Clear, Paragraph, Row, ScrollbarState, Table, TableState,
     },
     Frame,
 };
@@ -222,6 +221,7 @@ fn header_line3(app: &App, tc: &ThemeColors) -> Line<'static> {
 fn draw_header(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeColors) {
     let block = Block::default()
         .borders(Borders::ALL)
+        .border_set(super::glyphs::border())
         .border_style(Style::default().fg(tc.border));
     let lines = vec![
         header_line1(app, tc),
@@ -263,7 +263,11 @@ fn gbps_bar(gbps: f64, link_gbps: Option<f64>) -> String {
     let max = link_gbps.filter(|&r| r > 0.0).unwrap_or(RDMA_LINK_GBPS);
     let ratio = (gbps / max).clamp(0.0, 1.0);
     let filled = (ratio * BAR_WIDTH as f64).round() as usize;
-    format!("{}{}", "█".repeat(filled), "░".repeat(BAR_WIDTH - filled))
+    let (fill, empty) = super::glyphs::meter();
+    let mut bar = String::with_capacity(BAR_WIDTH);
+    bar.extend(std::iter::repeat(fill).take(filled));
+    bar.extend(std::iter::repeat(empty).take(BAR_WIDTH - filled));
+    bar
 }
 
 fn column_cell(col: &TableColumn, t: &PortThroughput, tc: &ThemeColors) -> Cell<'static> {
@@ -423,6 +427,7 @@ fn draw_gpu_table(frame: &mut Frame, app: &mut App, area: Rect, tc: &ThemeColors
         .block(
             Block::default()
                 .borders(Borders::ALL)
+        .border_set(super::glyphs::border())
                 .border_style(Style::default().fg(tc.border))
                 .title(title)
                 .title_style(Style::default().fg(tc.accent)),
@@ -432,7 +437,7 @@ fn draw_gpu_table(frame: &mut Frame, app: &mut App, area: Rect, tc: &ThemeColors
                 .bg(tc.highlight_bg)
                 .add_modifier(Modifier::BOLD),
         )
-        .highlight_symbol("▶ ");
+        .highlight_symbol(super::glyphs::cursor());
 
     let mut state = TableState::default();
     if !display.is_empty() {
@@ -452,11 +457,7 @@ fn draw_gpu_table(frame: &mut Frame, app: &mut App, area: Rect, tc: &ThemeColors
     if display.len() > area.height.saturating_sub(4) as usize {
         let mut v_scroll = ScrollbarState::new(display.len()).position(app.selected_row);
         frame.render_stateful_widget(
-            Scrollbar::new(ScrollbarOrientation::VerticalRight)
-                .thumb_symbol("▐")
-                .track_symbol(Some("│"))
-                .begin_symbol(Some("▲"))
-                .end_symbol(Some("▼"))
+            super::glyphs::v_scrollbar()
                 .thumb_style(Style::default().fg(tc.accent))
                 .track_style(Style::default().fg(tc.border)),
             area.inner(Margin {
@@ -561,6 +562,7 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect, tc: &ThemeColors) {
         .block(
             Block::default()
                 .borders(Borders::ALL)
+        .border_set(super::glyphs::border())
                 .border_style(Style::default().fg(tc.border))
                 .title(title)
                 .title_style(Style::default().fg(tc.accent)),
@@ -570,7 +572,7 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect, tc: &ThemeColors) {
                 .bg(tc.highlight_bg)
                 .add_modifier(Modifier::BOLD),
         )
-        .highlight_symbol("▶ ");
+        .highlight_symbol(super::glyphs::cursor());
 
     let mut state = TableState::default();
     if !display.is_empty() {
@@ -595,11 +597,7 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect, tc: &ThemeColors) {
     if display.len() > area.height.saturating_sub(4) as usize {
         let mut v_scroll = ScrollbarState::new(display.len()).position(app.selected_row);
         frame.render_stateful_widget(
-            Scrollbar::new(ScrollbarOrientation::VerticalRight)
-                .thumb_symbol("▐")
-                .track_symbol(Some("│"))
-                .begin_symbol(Some("▲"))
-                .end_symbol(Some("▼"))
+            super::glyphs::v_scrollbar()
                 .thumb_style(Style::default().fg(tc.accent))
                 .track_style(Style::default().fg(tc.border)),
             area.inner(Margin {
@@ -615,11 +613,7 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect, tc: &ThemeColors) {
     if all_cols.len() > cols_to_render.len() || app.h_scroll > 0 {
         let mut h_scroll = ScrollbarState::new(all_cols.len()).position(app.h_scroll);
         frame.render_stateful_widget(
-            Scrollbar::new(ScrollbarOrientation::HorizontalBottom)
-                .thumb_symbol("▬")
-                .track_symbol(Some("─"))
-                .begin_symbol(Some("◀"))
-                .end_symbol(Some("▶"))
+            super::glyphs::h_scrollbar()
                 .thumb_style(Style::default().fg(tc.accent))
                 .track_style(Style::default().fg(tc.border)),
             area.inner(Margin {
@@ -644,7 +638,7 @@ fn sparkline_str(data: &[f64], width: usize) -> String {
     while s.chars().count() < width {
         s.insert(0, ' ');
     }
-    s
+    super::glyphs::tr(&s).into_owned()
 }
 
 fn build_detail_lines(
@@ -1036,6 +1030,7 @@ fn draw_detail(frame: &mut Frame, app: &mut App, area: Rect, tc: &ThemeColors) {
             frame.render_widget(
                 Block::default()
                     .borders(Borders::ALL)
+        .border_set(super::glyphs::border())
                     .border_style(Style::default().fg(tc.border))
                     .title(" Detail "),
                 area,
@@ -1067,6 +1062,7 @@ fn draw_detail(frame: &mut Frame, app: &mut App, area: Rect, tc: &ThemeColors) {
 
     let block = Block::default()
         .borders(Borders::ALL)
+        .border_set(super::glyphs::border())
         .border_style(Style::default().fg(tc.border))
         .title(title)
         .title_style(Style::default().fg(tc.accent).add_modifier(Modifier::BOLD));
@@ -1122,10 +1118,11 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeColors) {
     } else {
         "  a:avg  w:set".to_string()
     };
-    let keys = format!(
+    let keys = super::glyphs::tr(&format!(
         " ↑↓/jk:nav  {}  t:theme  <>:refresh  r:rec  h:help  q:quit{}",
         hint, avg_hint
-    );
+    ))
+    .into_owned();
     let mode_style = Style::default()
         .fg(tc.status_fg)
         .bg(tc.status_bg)
@@ -1135,7 +1132,13 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeColors) {
     let mut spans = vec![mode];
     if let Some((secs, samples)) = app.recording_progress() {
         spans.push(Span::styled(
-            format!(" ● REC {}:{:02} ({}) ", secs / 60, secs % 60, samples),
+            super::glyphs::tr(&format!(
+                " ● REC {}:{:02} ({}) ",
+                secs / 60,
+                secs % 60,
+                samples
+            ))
+            .into_owned(),
             Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
         ));
     } else if let Some(msg) = &app.record_status {
@@ -1169,6 +1172,7 @@ fn draw_help_popup(frame: &mut Frame, tc: &ThemeColors) {
 
     let block = Block::default()
         .borders(Borders::ALL)
+        .border_set(super::glyphs::border())
         .border_style(Style::default().fg(tc.accent))
         .title(" Help (h/Esc to close) ")
         .title_style(Style::default().fg(tc.accent).add_modifier(Modifier::BOLD));
@@ -1195,6 +1199,7 @@ fn draw_window_input_popup(frame: &mut Frame, app: &App, tc: &ThemeColors) {
 
     let block = Block::default()
         .borders(Borders::ALL)
+        .border_set(super::glyphs::border())
         .border_style(Style::default().fg(tc.accent))
         .title(" Set Avg Window ")
         .title_style(Style::default().fg(tc.accent).add_modifier(Modifier::BOLD));
@@ -1239,6 +1244,7 @@ fn draw_column_picker(frame: &mut Frame, app: &App, tc: &ThemeColors) {
 
     let block = Block::default()
         .borders(Borders::ALL)
+        .border_set(super::glyphs::border())
         .border_style(Style::default().fg(tc.accent))
         .title(" Columns (Space:toggle  Esc:close) ")
         .title_style(Style::default().fg(tc.accent).add_modifier(Modifier::BOLD));
@@ -1265,7 +1271,7 @@ fn centered_rect(area: Rect, w: u16, h: u16) -> Rect {
 fn styled(text: &str, color: ratatui::style::Color, bold: bool) -> Span<'static> {
     let s = Style::default().fg(color);
     Span::styled(
-        text.to_string(),
+        super::glyphs::tr(text).into_owned(),
         if bold {
             s.add_modifier(Modifier::BOLD)
         } else {
@@ -1342,7 +1348,7 @@ fn truncate(s: &str, max: usize) -> String {
     if s.len() <= max {
         s.to_string()
     } else {
-        format!("{}…", &s[..max - 1])
+        format!("{}{}", &s[..max - 1], super::glyphs::tr("…"))
     }
 }
 
@@ -1366,7 +1372,8 @@ mod tab_bar_tests {
         let text = line_text(&bar);
         assert!(text.contains("RDMA"), "bar: {text:?}");
         assert!(text.contains("XGMI"), "bar: {text:?}");
-        assert!(text.contains('│'), "bar: {text:?}");
+        // Separator is '│' under UTF-8, '|' under a C locale (ASCII fallback).
+        assert!(text.contains('│') || text.contains('|'), "bar: {text:?}");
     }
 
     #[test]

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -262,9 +262,9 @@ fn gbps_bar(gbps: f64, link_gbps: Option<f64>) -> String {
     let ratio = (gbps / max).clamp(0.0, 1.0);
     let filled = (ratio * BAR_WIDTH as f64).round() as usize;
     let (fill, empty) = super::glyphs::meter();
-    let mut bar = String::with_capacity(BAR_WIDTH);
-    bar.extend(std::iter::repeat(fill).take(filled));
-    bar.extend(std::iter::repeat(empty).take(BAR_WIDTH - filled));
+    let mut bar = String::with_capacity(BAR_WIDTH * fill.len_utf8());
+    bar.extend(std::iter::repeat_n(fill, filled));
+    bar.extend(std::iter::repeat_n(empty, BAR_WIDTH - filled));
     bar
 }
 
@@ -1347,11 +1347,15 @@ fn fmt_mem_kb(kb: u64) -> String {
 }
 
 fn truncate(s: &str, max: usize) -> String {
-    if s.len() <= max {
-        s.to_string()
-    } else {
-        format!("{}{}", &s[..max - 1], super::glyphs::tr("…"))
+    // Count chars, not bytes: byte slicing panics mid-codepoint, and the
+    // ellipsis is 3 chars ("...") in ASCII mode, so budget for its width.
+    if s.chars().count() <= max {
+        return s.to_string();
     }
+    let dots = super::glyphs::tr("…");
+    let keep = max.saturating_sub(dots.chars().count());
+    let cut: String = s.chars().take(keep).collect();
+    format!("{cut}{dots}")
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Purpose

The TUI rendered mojibake on non-UTF-8 locales and in tmux clients without UTF-8 support.

Adds a glyphs module that detects UTF-8 capability once at startup (tmux #{client_utf8} flag → terminal cursor probe → locale fallback) and routes all UI glyphs — borders, meters, sparklines, scrollbars, cursors — through it, degrading to ASCII when UTF-8 isn't available. Also fixes a truncate() panic on multibyte input.

## Checklist

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes
- [x] Tested on RDMA-capable hardware (or explained why not in the Test Plan)
- [ ] Docs/README updated if behavior or flags changed
