### PR TITLE
perf: move sampling to a background thread and cache static driver facts

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -19,13 +19,15 @@ fn run_tui() -> io::Result<()> {
     let backend = ratatui::backend::CrosstermBackend::new(stdout);
     let mut terminal = ratatui::Terminal::new(backend)?;
     let mut app = tui::app::App::new();
-    let mut sampler = sampler::Sampler::spawn(app.refresh_interval);
+    let sampler = sampler::Sampler::spawn(app.refresh_interval);
 
     loop {
         if let Some(snap) = sampler.try_latest() {
             app.apply_snapshot(snap);
         }
-        app.sampler_dead = sampler.is_dead();
+        if app.sampler_error.is_none() {
+            app.sampler_error = sampler.death_reason();
+        }
 
         terminal.draw(|frame| tui::ui::draw(frame, &mut app))?;
         tui::events::handle_events(&mut app)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,13 +2,13 @@ mod net;
 mod netlink;
 mod nvlink;
 mod rdma;
+mod sampler;
 mod stat;
 mod trace;
 mod tui;
 mod xgmi;
 
 use std::io;
-use std::time::Instant;
 
 fn run_tui() -> io::Result<()> {
     crossterm::terminal::enable_raw_mode()?;
@@ -19,23 +19,25 @@ fn run_tui() -> io::Result<()> {
     let backend = ratatui::backend::CrosstermBackend::new(stdout);
     let mut terminal = ratatui::Terminal::new(backend)?;
     let mut app = tui::app::App::new();
-
-    let mut last_refresh = Instant::now() - app.refresh_interval;
+    let mut sampler = sampler::Sampler::spawn(app.refresh_interval);
 
     loop {
-        if last_refresh.elapsed() >= app.refresh_interval {
-            app.refresh_stats();
-            last_refresh = Instant::now();
+        if let Some(snap) = sampler.try_latest() {
+            app.apply_snapshot(snap);
         }
+        app.sampler_dead = sampler.is_dead();
 
         terminal.draw(|frame| tui::ui::draw(frame, &mut app))?;
         tui::events::handle_events(&mut app)?;
+        // `<`/`>` change app.refresh_interval; mirror it to the thread.
+        sampler.set_interval(app.refresh_interval);
 
         if app.should_quit {
             break;
         }
     }
 
+    sampler.stop();
     crossterm::terminal::disable_raw_mode()?;
     crossterm::execute!(
         terminal.backend_mut(),

--- a/src/nvlink.rs
+++ b/src/nvlink.rs
@@ -167,13 +167,20 @@ const LINK_SPEED_FIELD_IDS: [u32; 12] = [
 
 /// dlopen + nvmlInit once, kept for the process lifetime (nvmlShutdown is
 /// never called; process exit tears it down). A failed init retries on the
-/// next poll so a driver that loads after startup is still picked up.
+/// next poll; the lock serializes init so racing callers can never build
+/// and drop a second Nvml instance.
 fn nvml() -> Option<&'static Nvml> {
     static INSTANCE: OnceLock<Nvml> = OnceLock::new();
+    static INIT: Mutex<()> = Mutex::new(());
     if let Some(n) = INSTANCE.get() {
         return Some(n);
     }
-    Nvml::init().ok().map(|n| INSTANCE.get_or_init(|| n))
+    let _guard = INIT.lock().unwrap_or_else(|e| e.into_inner());
+    if let Some(n) = INSTANCE.get() {
+        return Some(n);
+    }
+    let n = Nvml::init().ok()?;
+    Some(INSTANCE.get_or_init(|| n))
 }
 
 /// Read NVLink statistics for every GPU in the system.

--- a/src/nvlink.rs
+++ b/src/nvlink.rs
@@ -7,7 +7,7 @@
 
 use std::collections::HashMap;
 use std::io;
-use std::sync::{Mutex, OnceLock};
+use std::sync::{LazyLock, Mutex, OnceLock};
 
 use nvml_wrapper::enum_wrappers::nv_link::{ErrorCounter, IntDeviceType};
 use nvml_wrapper::enums::device::SampleValue;
@@ -85,7 +85,8 @@ pub struct LinkSnapshot {
 }
 
 /// Static per-(gpu, link) facts that cannot change while the driver is
-/// loaded. Cached on first successful read; failures retry next poll.
+/// loaded. Cached once fully resolved; partial replies retry next poll.
+/// (`remote_pci_bdf` is optional: some remotes report no BDF at all.)
 #[derive(Clone)]
 struct LinkMeta {
     version: Option<u32>,
@@ -101,9 +102,9 @@ fn link_meta(
     link_id: u32,
     common_speed_gbps: Option<f64>,
 ) -> LinkMeta {
-    static CACHE: Mutex<Option<HashMap<(u32, u32), LinkMeta>>> = Mutex::new(None);
+    static CACHE: LazyLock<Mutex<HashMap<(u32, u32), LinkMeta>>> =
+        LazyLock::new(|| Mutex::new(HashMap::new()));
     let mut cache = CACHE.lock().unwrap_or_else(|e| e.into_inner());
-    let cache = cache.get_or_insert_with(HashMap::new);
     if let Some(meta) = cache.get(&(gpu, link_id)) {
         return meta.clone();
     }
@@ -114,12 +115,12 @@ fn link_meta(
         remote_pci_bdf: nvlink.remote_pci_info().ok().map(|p| p.bus_id),
         speed_gbps: read_link_speed_gbps(device, link_id).or(common_speed_gbps),
     };
-    // Only cache when the driver answered something; all-empty replies
-    // (e.g. during early link training) retry on the next poll.
+    // Cache only fully-resolved replies: a partial answer during link
+    // training (e.g. version ok, speed still 0) must retry next poll, or
+    // the missing fields would be frozen for the process lifetime.
     if meta.version.is_some()
-        || meta.remote_device_type != RemoteDeviceType::Unknown
-        || meta.remote_pci_bdf.is_some()
-        || meta.speed_gbps.is_some()
+        && meta.remote_device_type != RemoteDeviceType::Unknown
+        && meta.speed_gbps.is_some()
     {
         cache.insert((gpu, link_id), meta.clone());
     }
@@ -164,11 +165,15 @@ const LINK_SPEED_FIELD_IDS: [u32; 12] = [
     NVML_FI_DEV_NVLINK_SPEED_MBPS_L11,
 ];
 
-/// dlopen + nvmlInit exactly once per process; nvmlShutdown is never called
-/// (process exit tears it down). A failed init is cached as `None`.
+/// dlopen + nvmlInit once, kept for the process lifetime (nvmlShutdown is
+/// never called; process exit tears it down). A failed init retries on the
+/// next poll so a driver that loads after startup is still picked up.
 fn nvml() -> Option<&'static Nvml> {
-    static INSTANCE: OnceLock<Option<Nvml>> = OnceLock::new();
-    INSTANCE.get_or_init(|| Nvml::init().ok()).as_ref()
+    static INSTANCE: OnceLock<Nvml> = OnceLock::new();
+    if let Some(n) = INSTANCE.get() {
+        return Some(n);
+    }
+    Nvml::init().ok().map(|n| INSTANCE.get_or_init(|| n))
 }
 
 /// Read NVLink statistics for every GPU in the system.

--- a/src/nvlink.rs
+++ b/src/nvlink.rs
@@ -5,7 +5,9 @@
 //! throughput is read via the raw `nvmlDeviceGetFieldValues` entry point
 //! because `nvml-wrapper` does not expose a safe helper for those field IDs.
 
+use std::collections::HashMap;
 use std::io;
+use std::sync::{Mutex, OnceLock};
 
 use nvml_wrapper::enum_wrappers::nv_link::{ErrorCounter, IntDeviceType};
 use nvml_wrapper::enums::device::SampleValue;
@@ -82,6 +84,48 @@ pub struct LinkSnapshot {
     pub recovery_error_count: Option<u64>,
 }
 
+/// Static per-(gpu, link) facts that cannot change while the driver is
+/// loaded. Cached on first successful read; failures retry next poll.
+#[derive(Clone)]
+struct LinkMeta {
+    version: Option<u32>,
+    remote_device_type: RemoteDeviceType,
+    remote_pci_bdf: Option<String>,
+    speed_gbps: Option<f64>,
+}
+
+fn link_meta(
+    nvml: &Nvml,
+    device: &nvml_wrapper::Device<'_>,
+    gpu: u32,
+    link_id: u32,
+    common_speed_gbps: Option<f64>,
+) -> LinkMeta {
+    static CACHE: Mutex<Option<HashMap<(u32, u32), LinkMeta>>> = Mutex::new(None);
+    let mut cache = CACHE.lock().unwrap_or_else(|e| e.into_inner());
+    let cache = cache.get_or_insert_with(HashMap::new);
+    if let Some(meta) = cache.get(&(gpu, link_id)) {
+        return meta.clone();
+    }
+    let nvlink = device.link_wrapper_for(link_id);
+    let meta = LinkMeta {
+        version: nvlink.version().ok(),
+        remote_device_type: read_remote_device_type(nvml, device, link_id),
+        remote_pci_bdf: nvlink.remote_pci_info().ok().map(|p| p.bus_id),
+        speed_gbps: read_link_speed_gbps(device, link_id).or(common_speed_gbps),
+    };
+    // Only cache when the driver answered something; all-empty replies
+    // (e.g. during early link training) retry on the next poll.
+    if meta.version.is_some()
+        || meta.remote_device_type != RemoteDeviceType::Unknown
+        || meta.remote_pci_bdf.is_some()
+        || meta.speed_gbps.is_some()
+    {
+        cache.insert((gpu, link_id), meta.clone());
+    }
+    meta
+}
+
 /// Snapshot of every NVLink attached to one GPU.
 #[derive(Clone, Debug)]
 pub struct NvLinkSnapshot {
@@ -120,6 +164,13 @@ const LINK_SPEED_FIELD_IDS: [u32; 12] = [
     NVML_FI_DEV_NVLINK_SPEED_MBPS_L11,
 ];
 
+/// dlopen + nvmlInit exactly once per process; nvmlShutdown is never called
+/// (process exit tears it down). A failed init is cached as `None`.
+fn nvml() -> Option<&'static Nvml> {
+    static INSTANCE: OnceLock<Option<Nvml>> = OnceLock::new();
+    INSTANCE.get_or_init(|| Nvml::init().ok()).as_ref()
+}
+
 /// Read NVLink statistics for every GPU in the system.
 ///
 /// If NVML cannot be initialised (e.g. no NVIDIA driver loaded), an empty
@@ -127,9 +178,9 @@ const LINK_SPEED_FIELD_IDS: [u32; 12] = [
 /// Per-GPU or per-link failures are skipped silently and the remaining data
 /// is still returned.
 pub fn read_all_nvlink_stats() -> io::Result<Vec<NvLinkSnapshot>> {
-    let nvml = match Nvml::init() {
-        Ok(n) => n,
-        Err(_) => return Ok(Vec::new()),
+    let nvml = match nvml() {
+        Some(n) => n,
+        None => return Ok(Vec::new()),
     };
 
     let device_count = match nvml.device_count() {
@@ -139,7 +190,7 @@ pub fn read_all_nvlink_stats() -> io::Result<Vec<NvLinkSnapshot>> {
 
     let mut snapshots = Vec::with_capacity(device_count as usize);
     for idx in 0..device_count {
-        if let Some(snap) = read_device_snapshot(&nvml, idx) {
+        if let Some(snap) = read_device_snapshot(nvml, idx) {
             snapshots.push(snap);
         }
     }
@@ -159,29 +210,33 @@ fn read_device_snapshot(nvml: &Nvml, idx: u32) -> Option<NvLinkSnapshot> {
     for link_id in 0..link_count {
         let nvlink = device.link_wrapper_for(link_id);
         let is_active = nvlink.is_active().unwrap_or(false);
-        let version = nvlink.version().ok();
-        let remote_device_type = read_remote_device_type(nvml, &device, link_id);
-        let remote_pci_bdf = nvlink.remote_pci_info().ok().map(|p| p.bus_id);
+        // Static facts are cached; inactive links skip them entirely
+        // (matching the old behavior of speed, extended to all metadata).
+        let meta = if is_active {
+            link_meta(nvml, &device, idx, link_id, common_speed_gbps)
+        } else {
+            LinkMeta {
+                version: None,
+                remote_device_type: RemoteDeviceType::Unknown,
+                remote_pci_bdf: None,
+                speed_gbps: None,
+            }
+        };
         let crc_error_count = nvlink.error_counter(ErrorCounter::DlCrcFlit).ok();
         let replay_error_count = nvlink.error_counter(ErrorCounter::DlReplay).ok();
         let recovery_error_count = nvlink.error_counter(ErrorCounter::DlRecovery).ok();
         let (tx_bytes, rx_bytes) = read_link_throughput(nvml, &device, link_id);
-        let speed_gbps = if is_active {
-            read_link_speed_gbps(&device, link_id).or(common_speed_gbps)
-        } else {
-            None
-        };
-        if let Some(s) = speed_gbps {
+        if let Some(s) = meta.speed_gbps {
             total_speed_gbps += s;
         }
 
         links.push(LinkSnapshot {
             link_id,
             is_active,
-            version,
-            speed_gbps,
-            remote_device_type,
-            remote_pci_bdf,
+            version: meta.version,
+            speed_gbps: meta.speed_gbps,
+            remote_device_type: meta.remote_device_type,
+            remote_pci_bdf: meta.remote_pci_bdf,
             tx_bytes,
             rx_bytes,
             crc_error_count,

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -1,114 +1,145 @@
 //! Background sampling thread. Collects every subsystem into a `Snapshot`
-//! and ships it to the UI over mpsc, so slow driver calls (NVML/amdsmi
-//! init, netlink) never block rendering or input.
+//! and hands it to the UI through a single-slot mailbox, so slow driver
+//! calls (NVML/amdsmi init, netlink) never block rendering or input.
 
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::mpsc::{Receiver, Sender, TryRecvError};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use crate::{net, nvlink, stat, xgmi};
 
 /// Everything one sampling pass produces. Raw counters only; delta/rate
 /// math stays on the UI thread where the previous snapshot lives.
+/// Each field is None when its read failed, so one failing subsystem
+/// (e.g. a kernel without rdma netlink) never blocks the others.
 pub struct Snapshot {
-    /// None when the netlink read failed; the UI skips the snapshot to
-    /// avoid diffing cumulative counters against a blanked baseline.
     pub stats: Option<Vec<stat::PortStat>>,
-    pub ifstats: Vec<net::IfStats>,
-    pub nvlink: Vec<nvlink::NvLinkSnapshot>,
-    pub xgmi: Vec<xgmi::XgmiSnapshot>,
-    pub processes: Vec<stat::ProcessRdmaInfo>,
+    pub ifstats: Option<Vec<net::IfStats>>,
+    pub nvlink: Option<Vec<nvlink::NvLinkSnapshot>>,
+    pub xgmi: Option<Vec<xgmi::XgmiSnapshot>>,
+    pub processes: Option<Vec<stat::ProcessRdmaInfo>>,
     pub taken_at: Instant,
 }
 
 fn collect() -> Snapshot {
+    // Stamp before the reads: the UI derives rates from taken_at deltas, so
+    // a slow pass (e.g. first-time driver init) must not inflate elapsed.
+    let taken_at = Instant::now();
     let processes = stat::read_all_qps()
-        .map(|qps| stat::aggregate_by_process(&qps))
-        .unwrap_or_default();
+        .ok()
+        .map(|qps| stat::aggregate_by_process(&qps));
     Snapshot {
         stats: stat::read_all_stats().ok(),
-        ifstats: net::read_all_ifstats().unwrap_or_default(),
-        nvlink: nvlink::read_all_nvlink_stats().unwrap_or_default(),
-        xgmi: xgmi::read_all_xgmi_stats().unwrap_or_default(),
+        ifstats: net::read_all_ifstats().ok(),
+        nvlink: nvlink::read_all_nvlink_stats().ok(),
+        xgmi: xgmi::read_all_xgmi_stats().ok(),
         processes,
-        taken_at: Instant::now(),
+        taken_at,
     }
 }
 
+/// State shared between the sampling thread and the UI-side `Sampler`.
+struct Shared {
+    /// Latest snapshot; the thread overwrites, the UI takes. A single slot
+    /// caps memory at one snapshot even if the UI stalls for hours.
+    slot: Mutex<Option<Snapshot>>,
+    interval_ms: AtomicU64,
+    stop: AtomicBool,
+    /// Panic message when the thread died; the UI surfaces it, since the
+    /// default panic output is lost inside the alternate screen.
+    died: Mutex<Option<String>>,
+}
+
 pub struct Sampler {
-    rx: Receiver<Snapshot>,
-    interval_ms: Arc<AtomicU64>,
-    stop: Arc<AtomicBool>,
-    dead: bool,
+    shared: Arc<Shared>,
 }
 
 impl Sampler {
     /// Spawn the sampling thread. It samples immediately (the baseline),
     /// then keeps sampling at the current interval until stopped.
     pub fn spawn(interval: Duration) -> Self {
-        let interval_ms = Arc::new(AtomicU64::new(interval.as_millis() as u64));
-        let stop = Arc::new(AtomicBool::new(false));
-        let (tx, rx) = std::sync::mpsc::channel();
-        let (t_interval, t_stop) = (interval_ms.clone(), stop.clone());
-        std::thread::spawn(move || run(tx, t_interval, t_stop));
-        Self {
-            rx,
-            interval_ms,
-            stop,
-            dead: false,
-        }
+        let shared = Arc::new(Shared {
+            slot: Mutex::new(None),
+            interval_ms: AtomicU64::new(interval.as_millis() as u64),
+            stop: AtomicBool::new(false),
+            died: Mutex::new(None),
+        });
+        let thread_shared = shared.clone();
+        std::thread::spawn(move || run(&thread_shared));
+        Self { shared }
     }
 
-    /// Newest snapshot, draining any backlog. `None` when nothing arrived.
-    pub fn try_latest(&mut self) -> Option<Snapshot> {
-        let mut latest = None;
-        loop {
-            match self.rx.try_recv() {
-                Ok(s) => latest = Some(s),
-                Err(TryRecvError::Empty) => break,
-                Err(TryRecvError::Disconnected) => {
-                    self.dead = true;
-                    break;
-                }
-            }
-        }
-        latest
+    /// Latest snapshot, if a new one arrived since the last call.
+    pub fn try_latest(&self) -> Option<Snapshot> {
+        self.shared
+            .slot
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .take()
     }
 
-    /// True once the sampling thread has died (channel disconnected).
-    pub fn is_dead(&self) -> bool {
-        self.dead
+    /// The captured panic message when the thread died; None while alive.
+    pub fn death_reason(&self) -> Option<String> {
+        self.shared
+            .died
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
     }
 
     pub fn set_interval(&self, interval: Duration) {
-        self.interval_ms
+        self.shared
+            .interval_ms
             .store(interval.as_millis() as u64, Ordering::Relaxed);
     }
 
     /// Ask the thread to exit. Detach, never join: a thread stuck inside a
     /// driver call must not block process exit.
     pub fn stop(&self) {
-        self.stop.store(true, Ordering::Relaxed);
+        self.shared.stop.store(true, Ordering::Relaxed);
     }
 }
 
-fn run(tx: Sender<Snapshot>, interval_ms: Arc<AtomicU64>, stop: Arc<AtomicBool>) {
+impl Drop for Sampler {
+    // The mailbox has no disconnect signal (unlike a channel), so stopping
+    // on drop is what keeps the thread from sampling forever on error paths.
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+/// Render a `catch_unwind` payload (typically &str or String) for the UI.
+fn panic_message(payload: Box<dyn std::any::Any + Send>) -> String {
+    if let Some(s) = payload.downcast_ref::<&str>() {
+        (*s).to_string()
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "unknown panic".to_string()
+    }
+}
+
+fn run(shared: &Shared) {
     loop {
-        if stop.load(Ordering::Relaxed) {
+        if shared.stop.load(Ordering::Relaxed) {
             return;
         }
-        let snap = collect();
-        if tx.send(snap).is_err() {
-            return; // UI gone
-        }
+        let snap = match std::panic::catch_unwind(collect) {
+            Ok(s) => s,
+            Err(payload) => {
+                let mut died = shared.died.lock().unwrap_or_else(|e| e.into_inner());
+                *died = Some(panic_message(payload));
+                return;
+            }
+        };
+        *shared.slot.lock().unwrap_or_else(|e| e.into_inner()) = Some(snap);
         // Sleep in short slices so interval changes and stop apply quickly.
         let started = Instant::now();
         loop {
-            if stop.load(Ordering::Relaxed) {
+            if shared.stop.load(Ordering::Relaxed) {
                 return;
             }
-            let interval = Duration::from_millis(interval_ms.load(Ordering::Relaxed));
+            let interval = Duration::from_millis(shared.interval_ms.load(Ordering::Relaxed));
             if started.elapsed() >= interval {
                 break;
             }

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -8,31 +8,43 @@ use std::time::{Duration, Instant};
 
 use crate::{net, nvlink, stat, xgmi};
 
+/// One subsystem's reading stamped right at its own read, so rate math
+/// never absorbs another subsystem's latency (e.g. a driver init earlier
+/// in the same pass).
+pub struct Sample<T> {
+    pub data: T,
+    pub taken_at: Instant,
+}
+
+fn sample<T>(read: impl FnOnce() -> std::io::Result<T>) -> Option<Sample<T>> {
+    let taken_at = Instant::now();
+    read().ok().map(|data| Sample { data, taken_at })
+}
+
 /// Everything one sampling pass produces. Raw counters only; delta/rate
 /// math stays on the UI thread where the previous snapshot lives.
 /// Each field is None when its read failed, so one failing subsystem
 /// (e.g. a kernel without rdma netlink) never blocks the others.
 pub struct Snapshot {
-    pub stats: Option<Vec<stat::PortStat>>,
-    pub ifstats: Option<Vec<net::IfStats>>,
-    pub nvlink: Option<Vec<nvlink::NvLinkSnapshot>>,
-    pub xgmi: Option<Vec<xgmi::XgmiSnapshot>>,
+    pub stats: Option<Sample<Vec<stat::PortStat>>>,
+    pub ifstats: Option<Sample<Vec<net::IfStats>>>,
+    pub nvlink: Option<Sample<Vec<nvlink::NvLinkSnapshot>>>,
+    pub xgmi: Option<Sample<Vec<xgmi::XgmiSnapshot>>>,
     pub processes: Option<Vec<stat::ProcessRdmaInfo>>,
+    /// Pass start; used for the duplicate guard, staleness, and trace ts.
     pub taken_at: Instant,
 }
 
 fn collect() -> Snapshot {
-    // Stamp before the reads: the UI derives rates from taken_at deltas, so
-    // a slow pass (e.g. first-time driver init) must not inflate elapsed.
     let taken_at = Instant::now();
     let processes = stat::read_all_qps()
         .ok()
         .map(|qps| stat::aggregate_by_process(&qps));
     Snapshot {
-        stats: stat::read_all_stats().ok(),
-        ifstats: net::read_all_ifstats().ok(),
-        nvlink: nvlink::read_all_nvlink_stats().ok(),
-        xgmi: xgmi::read_all_xgmi_stats().ok(),
+        stats: sample(stat::read_all_stats),
+        ifstats: sample(net::read_all_ifstats),
+        nvlink: sample(nvlink::read_all_nvlink_stats),
+        xgmi: sample(xgmi::read_all_xgmi_stats),
         processes,
         taken_at,
     }

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -8,17 +8,20 @@ use std::time::{Duration, Instant};
 
 use crate::{net, nvlink, stat, xgmi};
 
-/// One subsystem's reading stamped right at its own read, so rate math
-/// never absorbs another subsystem's latency (e.g. a driver init earlier
-/// in the same pass).
+/// One subsystem's reading, stamped as its read completes, so rate math
+/// never absorbs another subsystem's latency nor this one's own lazy
+/// setup (e.g. first-time driver init runs before the counters are read).
 pub struct Sample<T> {
     pub data: T,
     pub taken_at: Instant,
 }
 
 fn sample<T>(read: impl FnOnce() -> std::io::Result<T>) -> Option<Sample<T>> {
-    let taken_at = Instant::now();
-    read().ok().map(|data| Sample { data, taken_at })
+    let data = read().ok()?;
+    Some(Sample {
+        data,
+        taken_at: Instant::now(),
+    })
 }
 
 /// Everything one sampling pass produces. Raw counters only; delta/rate

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -72,7 +72,7 @@ impl Sampler {
     pub fn spawn(interval: Duration) -> Self {
         let shared = Arc::new(Shared {
             slot: Mutex::new(None),
-            interval_ms: AtomicU64::new(interval.as_millis() as u64),
+            interval_ms: AtomicU64::new(interval_to_ms(interval)),
             stop: AtomicBool::new(false),
             died: Mutex::new(None),
         });
@@ -102,7 +102,7 @@ impl Sampler {
     pub fn set_interval(&self, interval: Duration) {
         self.shared
             .interval_ms
-            .store(interval.as_millis() as u64, Ordering::Relaxed);
+            .store(interval_to_ms(interval), Ordering::Relaxed);
     }
 
     /// Ask the thread to exit. Detach, never join: a thread stuck inside a
@@ -118,6 +118,12 @@ impl Drop for Sampler {
     fn drop(&mut self) {
         self.stop();
     }
+}
+
+/// Interval as stored millis, clamped to 1ms: a zero value would make the
+/// sampling loop spin with no sleep at all.
+fn interval_to_ms(interval: Duration) -> u64 {
+    (interval.as_millis() as u64).max(1)
 }
 
 /// Render a `catch_unwind` payload (typically &str or String) for the UI.

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -1,0 +1,118 @@
+//! Background sampling thread. Collects every subsystem into a `Snapshot`
+//! and ships it to the UI over mpsc, so slow driver calls (NVML/amdsmi
+//! init, netlink) never block rendering or input.
+
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::mpsc::{Receiver, Sender, TryRecvError};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use crate::{net, nvlink, stat, xgmi};
+
+/// Everything one sampling pass produces. Raw counters only; delta/rate
+/// math stays on the UI thread where the previous snapshot lives.
+pub struct Snapshot {
+    /// None when the netlink read failed; the UI skips the snapshot to
+    /// avoid diffing cumulative counters against a blanked baseline.
+    pub stats: Option<Vec<stat::PortStat>>,
+    pub ifstats: Vec<net::IfStats>,
+    pub nvlink: Vec<nvlink::NvLinkSnapshot>,
+    pub xgmi: Vec<xgmi::XgmiSnapshot>,
+    pub processes: Vec<stat::ProcessRdmaInfo>,
+    pub taken_at: Instant,
+}
+
+fn collect() -> Snapshot {
+    let processes = stat::read_all_qps()
+        .map(|qps| stat::aggregate_by_process(&qps))
+        .unwrap_or_default();
+    Snapshot {
+        stats: stat::read_all_stats().ok(),
+        ifstats: net::read_all_ifstats().unwrap_or_default(),
+        nvlink: nvlink::read_all_nvlink_stats().unwrap_or_default(),
+        xgmi: xgmi::read_all_xgmi_stats().unwrap_or_default(),
+        processes,
+        taken_at: Instant::now(),
+    }
+}
+
+pub struct Sampler {
+    rx: Receiver<Snapshot>,
+    interval_ms: Arc<AtomicU64>,
+    stop: Arc<AtomicBool>,
+    dead: bool,
+}
+
+impl Sampler {
+    /// Spawn the sampling thread. It samples immediately (the baseline),
+    /// then keeps sampling at the current interval until stopped.
+    pub fn spawn(interval: Duration) -> Self {
+        let interval_ms = Arc::new(AtomicU64::new(interval.as_millis() as u64));
+        let stop = Arc::new(AtomicBool::new(false));
+        let (tx, rx) = std::sync::mpsc::channel();
+        let (t_interval, t_stop) = (interval_ms.clone(), stop.clone());
+        std::thread::spawn(move || run(tx, t_interval, t_stop));
+        Self {
+            rx,
+            interval_ms,
+            stop,
+            dead: false,
+        }
+    }
+
+    /// Newest snapshot, draining any backlog. `None` when nothing arrived.
+    pub fn try_latest(&mut self) -> Option<Snapshot> {
+        let mut latest = None;
+        loop {
+            match self.rx.try_recv() {
+                Ok(s) => latest = Some(s),
+                Err(TryRecvError::Empty) => break,
+                Err(TryRecvError::Disconnected) => {
+                    self.dead = true;
+                    break;
+                }
+            }
+        }
+        latest
+    }
+
+    /// True once the sampling thread has died (channel disconnected).
+    pub fn is_dead(&self) -> bool {
+        self.dead
+    }
+
+    pub fn set_interval(&self, interval: Duration) {
+        self.interval_ms
+            .store(interval.as_millis() as u64, Ordering::Relaxed);
+    }
+
+    /// Ask the thread to exit. Detach, never join: a thread stuck inside a
+    /// driver call must not block process exit.
+    pub fn stop(&self) {
+        self.stop.store(true, Ordering::Relaxed);
+    }
+}
+
+fn run(tx: Sender<Snapshot>, interval_ms: Arc<AtomicU64>, stop: Arc<AtomicBool>) {
+    loop {
+        if stop.load(Ordering::Relaxed) {
+            return;
+        }
+        let snap = collect();
+        if tx.send(snap).is_err() {
+            return; // UI gone
+        }
+        // Sleep in short slices so interval changes and stop apply quickly.
+        let started = Instant::now();
+        loop {
+            if stop.load(Ordering::Relaxed) {
+                return;
+            }
+            let interval = Duration::from_millis(interval_ms.load(Ordering::Relaxed));
+            if started.elapsed() >= interval {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+    }
+}

--- a/src/stat.rs
+++ b/src/stat.rs
@@ -1,8 +1,6 @@
 use crate::netlink::*;
 use crate::rdma::*;
-use std::collections::HashMap;
 use std::io;
-use std::sync::Mutex;
 
 #[derive(Clone, Debug)]
 /// A single hardware counter name/value pair.
@@ -97,21 +95,13 @@ fn parse_port_stat(nlmsg: &NlMsg) -> Option<PortStat> {
 }
 
 /// Parse the port line rate from sysfs, e.g. "400 Gb/sec (4X NDR)" -> 400.0.
-/// The rate is static while the link is up; successful reads are cached,
-/// failed reads retry next poll (link may still be training at startup).
+/// Read fresh every poll on purpose: a down port reports an SDR placeholder
+/// and links can retrain at a different speed, so caching would freeze a
+/// wrong utilization denominator for the process lifetime.
 fn read_port_link_gbps(dev_name: &str, port: u32) -> Option<f64> {
-    static CACHE: Mutex<Option<HashMap<(String, u32), f64>>> = Mutex::new(None);
-    let mut cache = CACHE.lock().unwrap_or_else(|e| e.into_inner());
-    let cache = cache.get_or_insert_with(HashMap::new);
-    let key = (dev_name.to_string(), port);
-    if let Some(&gbps) = cache.get(&key) {
-        return Some(gbps);
-    }
     let path = format!("/sys/class/infiniband/{}/ports/{}/rate", dev_name, port);
     let raw = std::fs::read_to_string(path).ok()?;
-    let gbps = raw.split_whitespace().next()?.parse::<f64>().ok()?;
-    cache.insert(key, gbps);
-    Some(gbps)
+    raw.split_whitespace().next()?.parse::<f64>().ok()
 }
 
 // Names whose values in /sys/.../counters/ are in 4-byte words per IB spec.

--- a/src/stat.rs
+++ b/src/stat.rs
@@ -1,6 +1,8 @@
 use crate::netlink::*;
 use crate::rdma::*;
+use std::collections::HashMap;
 use std::io;
+use std::sync::Mutex;
 
 #[derive(Clone, Debug)]
 /// A single hardware counter name/value pair.
@@ -95,10 +97,21 @@ fn parse_port_stat(nlmsg: &NlMsg) -> Option<PortStat> {
 }
 
 /// Parse the port line rate from sysfs, e.g. "400 Gb/sec (4X NDR)" -> 400.0.
+/// The rate is static while the link is up; successful reads are cached,
+/// failed reads retry next poll (link may still be training at startup).
 fn read_port_link_gbps(dev_name: &str, port: u32) -> Option<f64> {
+    static CACHE: Mutex<Option<HashMap<(String, u32), f64>>> = Mutex::new(None);
+    let mut cache = CACHE.lock().unwrap_or_else(|e| e.into_inner());
+    let cache = cache.get_or_insert_with(HashMap::new);
+    let key = (dev_name.to_string(), port);
+    if let Some(&gbps) = cache.get(&key) {
+        return Some(gbps);
+    }
     let path = format!("/sys/class/infiniband/{}/ports/{}/rate", dev_name, port);
     let raw = std::fs::read_to_string(path).ok()?;
-    raw.split_whitespace().next()?.parse::<f64>().ok()
+    let gbps = raw.split_whitespace().next()?.parse::<f64>().ok()?;
+    cache.insert(key, gbps);
+    Some(gbps)
 }
 
 // Names whose values in /sys/.../counters/ are in 4-byte words per IB spec.

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -38,9 +38,9 @@ impl Recorder {
     }
 
     /// Record one interval's metrics, timestamped relative to record start.
-    /// `taken_at` is when the counters were read (sampler-side), so trace
-    /// spacing is immune to UI queue and event-poll latency; a sample taken
-    /// before recording started saturates to ts 0.
+    /// `taken_at` is the sampling pass start (sampler-side), so trace spacing
+    /// is immune to UI queue and event-poll latency; a sample taken before
+    /// recording started saturates to ts 0.
     pub fn push(&mut self, taken_at: Instant, ports: Vec<PortMetrics>) {
         let ts_us = taken_at.saturating_duration_since(self.start).as_micros() as u64;
         self.samples.push(TraceSample { ts_us, ports });

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -38,8 +38,11 @@ impl Recorder {
     }
 
     /// Record one interval's metrics, timestamped relative to record start.
-    pub fn push(&mut self, ports: Vec<PortMetrics>) {
-        let ts_us = self.start.elapsed().as_micros() as u64;
+    /// `taken_at` is when the counters were read (sampler-side), so trace
+    /// spacing is immune to UI queue and event-poll latency; a sample taken
+    /// before recording started saturates to ts 0.
+    pub fn push(&mut self, taken_at: Instant, ports: Vec<PortMetrics>) {
+        let ts_us = taken_at.saturating_duration_since(self.start).as_micros() as u64;
         self.samples.push(TraceSample { ts_us, ports });
     }
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -144,8 +144,9 @@ impl TableColumn {
 
 pub const BAR_WIDTH: usize = 12;
 
-/// Stats refresh interval bounds (seconds). Floor matches the 200ms event-poll
-/// so input stays responsive even at the fastest setting.
+/// Stats refresh interval bounds (seconds). Sampling runs on a background
+/// thread, so the floor only bounds sampler load; it must stay above the
+/// 0.1s duplicate-snapshot guard in `apply_snapshot`.
 pub const REFRESH_DEFAULT_SECS: f64 = 1.0;
 const REFRESH_MIN_SECS: f64 = 0.2;
 const REFRESH_MAX_SECS: f64 = 10.0;
@@ -356,9 +357,21 @@ pub struct App {
     pub cpu_history: Vec<f32>,
     prev_stats: Vec<PortStat>,
     prev_ifstats: Vec<IfStats>,
+    // Per-subsystem baselines: each timestamp marks when its subsystem last
+    // read successfully, so a failed read holds that subsystem's state and
+    // the next success diffs over the true elapsed span.
+    prev_stats_at: Option<Instant>,
+    prev_ifstats_at: Option<Instant>,
+    prev_nvlink_at: Option<Instant>,
+    prev_xgmi_at: Option<Instant>,
     prev_taken_at: Option<Instant>,
+    rdma_rows: Vec<PortThroughput>,
+    nvlink_rows: Vec<PortThroughput>,
+    xgmi_rows: Vec<PortThroughput>,
+    net_rate: NetRate,
     pub has_data: bool,
-    pub sampler_dead: bool,
+    /// Panic message from a dead sampler thread; None while it is alive.
+    pub sampler_error: Option<String>,
     pub rolling_avg: RollingAvgState,
     pub show_rolling_avg: bool,
     pub show_window_input: bool,
@@ -437,9 +450,17 @@ impl App {
             cpu_history: Vec::with_capacity(HISTORY_LEN),
             prev_stats: Vec::new(),
             prev_ifstats: Vec::new(),
+            prev_stats_at: None,
+            prev_ifstats_at: None,
+            prev_nvlink_at: None,
+            prev_xgmi_at: None,
             prev_taken_at: None,
+            rdma_rows: Vec::new(),
+            nvlink_rows: Vec::new(),
+            xgmi_rows: Vec::new(),
+            net_rate: NetRate::default(),
             has_data: false,
-            sampler_dead: false,
+            sampler_error: None,
             rolling_avg: RollingAvgState::new(ROLLING_AVG_DEFAULT_WINDOW),
             show_rolling_avg: false,
             show_window_input: false,
@@ -462,64 +483,69 @@ impl App {
         }
     }
 
-    /// Fold one sampler snapshot into the app state. The first snapshot is
-    /// the baseline: rows render immediately with zero rates (prev == curr),
-    /// real rates appear from the second snapshot on. Elapsed time comes
-    /// from sampler-side timestamps so UI queue latency can't skew rates.
+    /// Fold one sampler snapshot into the app state, per subsystem: a failed
+    /// read (None) keeps that subsystem's previous rows and baseline, so one
+    /// broken source never blocks the others. Each subsystem's first success
+    /// is its baseline (prev == curr, zero rates); real rates follow. Elapsed
+    /// comes from sampler-side timestamps so UI queue latency can't skew rates.
     pub fn apply_snapshot(&mut self, snap: crate::sampler::Snapshot) {
-        // A failed RDMA read poisons delta math (counters vs blank baseline);
-        // skip the whole snapshot, matching the old early-return.
-        let Some(stats) = snap.stats else {
-            return;
-        };
-        let elapsed = match self.prev_taken_at {
-            Some(prev) => {
-                let e = snap.taken_at.duration_since(prev).as_secs_f64();
-                if e < 0.1 {
-                    return;
-                }
-                e
+        if let Some(prev) = self.prev_taken_at {
+            if snap.taken_at.duration_since(prev).as_secs_f64() < 0.1 {
+                return;
             }
-            None => 1.0, // baseline: prev==curr below, so rates are zero
-        };
-        let baseline = self.prev_taken_at.is_none();
+        }
+        // Per-subsystem elapsed: measured to that subsystem's last success,
+        // so a skipped tick diffs cumulative counters over the true span.
+        let since = |at: Option<Instant>| at.map(|a| snap.taken_at.duration_since(a).as_secs_f64());
 
-        let prev_stats = if baseline { &stats } else { &self.prev_stats };
-        self.throughputs = compute_throughputs(prev_stats, &stats, elapsed);
+        if let Some(stats) = snap.stats {
+            self.rdma_rows = match since(self.prev_stats_at) {
+                Some(e) => compute_throughputs(&self.prev_stats, &stats, e),
+                None => compute_throughputs(&stats, &stats, 1.0), // baseline
+            };
+            self.prev_stats = stats;
+            self.prev_stats_at = Some(snap.taken_at);
+        }
 
-        let prev_nvlink = if baseline {
-            &snap.nvlink
-        } else {
-            &self.prev_nvlink
-        };
-        let mut nvlink_rows = compute_nvlink_throughputs(prev_nvlink, &snap.nvlink, elapsed);
-        self.throughputs.append(&mut nvlink_rows);
+        if let Some(nvlink) = snap.nvlink {
+            self.nvlink_rows = match since(self.prev_nvlink_at) {
+                Some(e) => compute_nvlink_throughputs(&self.prev_nvlink, &nvlink, e),
+                None => compute_nvlink_throughputs(&nvlink, &nvlink, 1.0), // baseline
+            };
+            self.prev_nvlink = nvlink;
+            self.prev_nvlink_at = Some(snap.taken_at);
+        }
 
-        let prev_xgmi = if baseline {
-            &snap.xgmi
-        } else {
-            &self.prev_xgmi
-        };
-        let mut xgmi_rows = compute_xgmi_throughputs(prev_xgmi, &snap.xgmi, elapsed);
-        self.throughputs.append(&mut xgmi_rows);
+        if let Some(xgmi) = snap.xgmi {
+            self.xgmi_rows = match since(self.prev_xgmi_at) {
+                Some(e) => compute_xgmi_throughputs(&self.prev_xgmi, &xgmi, e),
+                None => compute_xgmi_throughputs(&xgmi, &xgmi, 1.0), // baseline
+            };
+            self.prev_xgmi = xgmi;
+            self.prev_xgmi_at = Some(snap.taken_at);
+        }
+
+        if let Some(ifstats) = snap.ifstats {
+            if let Some(e) = since(self.prev_ifstats_at) {
+                self.net_rate = net::compute_net_rate(&self.prev_ifstats, &ifstats, e);
+            }
+            self.prev_ifstats = ifstats;
+            self.prev_ifstats_at = Some(snap.taken_at);
+        }
+
+        if let Some(processes) = snap.processes {
+            self.processes = processes;
+        }
+
+        self.throughputs = self.rdma_rows.clone();
+        self.throughputs.extend(self.nvlink_rows.iter().cloned());
+        self.throughputs.extend(self.xgmi_rows.iter().cloned());
 
         // Stable display order: sort once here so history, rolling averages,
         // recording, and the display all inherit the same order.
         sort_by_device_order(&mut self.throughputs);
         detect_tabs(&mut self.seen_tabs, &self.throughputs);
 
-        let prev_if = if baseline {
-            &snap.ifstats
-        } else {
-            &self.prev_ifstats
-        };
-        let net_rate = net::compute_net_rate(prev_if, &snap.ifstats, elapsed);
-
-        self.prev_stats = stats;
-        self.prev_nvlink = snap.nvlink;
-        self.prev_xgmi = snap.xgmi;
-        self.prev_ifstats = snap.ifstats;
-        self.processes = snap.processes;
         self.prev_taken_at = Some(snap.taken_at);
         self.has_data = true;
 
@@ -527,14 +553,24 @@ impl App {
         self.update_history();
         self.rolling_avg.push(&self.throughputs);
         if let Some(rec) = &mut self.recorder {
-            rec.push(port_metrics(&self.throughputs));
+            rec.push(snap.taken_at, port_metrics(&self.throughputs));
         }
-        self.sysinfo = read_sysinfo(net_rate);
+        self.sysinfo = read_sysinfo(self.net_rate.clone());
         if self.cpu_history.len() >= HISTORY_LEN {
             self.cpu_history.remove(0);
         }
         self.cpu_history.push(self.sysinfo.cpu_pct);
         self.recompute_display();
+    }
+
+    /// Seconds since the last applied snapshot when it exceeds a staleness
+    /// threshold (3x the refresh interval, min 2s); `None` while fresh.
+    /// Lets the UI flag a stalled sampler, which `sampler_error` cannot see.
+    pub fn stale_secs(&self) -> Option<u64> {
+        let at = self.prev_taken_at?;
+        let threshold = (self.refresh_interval * 3).max(Duration::from_secs(2));
+        let age = at.elapsed();
+        (age > threshold).then_some(age.as_secs())
     }
 
     /// Recompute the cached display throughputs (call after any change to
@@ -2255,10 +2291,30 @@ mod apply_snapshot_tests {
     fn snapshot(stats: Vec<PortStat>, taken_at: Instant) -> Snapshot {
         Snapshot {
             stats: Some(stats),
-            ifstats: Vec::new(),
-            nvlink: Vec::new(),
-            xgmi: Vec::new(),
-            processes: Vec::new(),
+            ifstats: Some(Vec::new()),
+            nvlink: Some(Vec::new()),
+            xgmi: Some(Vec::new()),
+            processes: Some(Vec::new()),
+            taken_at,
+        }
+    }
+
+    fn gpu_snapshot(tx_bytes: u64, taken_at: Instant) -> Snapshot {
+        let gpu = crate::nvlink::NvLinkSnapshot {
+            gpu_index: 0,
+            gpu_name: "test-gpu".to_string(),
+            link_count: 0,
+            link_gbps: None,
+            tx_bytes: Some(tx_bytes),
+            rx_bytes: Some(0),
+            links: Vec::new(),
+        };
+        Snapshot {
+            stats: None, // e.g. kernel without rdma netlink support
+            ifstats: Some(Vec::new()),
+            nvlink: Some(vec![gpu]),
+            xgmi: Some(Vec::new()),
+            processes: Some(Vec::new()),
             taken_at,
         }
     }
@@ -2297,17 +2353,25 @@ mod apply_snapshot_tests {
         ));
         // Skipped: rates still the baseline zeros.
         assert_eq!(app.throughputs[0].tx_gbps, 0.0);
+        // The skipped counters must not have become the new baseline: the
+        // next snapshot diffs against the ORIGINAL t0 baseline (0 bytes).
+        app.apply_snapshot(snapshot(
+            vec![port_stat("mlx5_0", 1_000_000_000)],
+            t0 + Duration::from_secs(2),
+        ));
+        // 1e9 bytes * 8 / 2 s / 1e9 = 4.0 Gbps (4.1 would mean 999 leaked in)
+        assert!((app.throughputs[0].tx_gbps - 4.0).abs() < 1e-9);
     }
 
     #[test]
-    fn failed_rdma_read_skips_snapshot() {
+    fn failed_rdma_read_holds_rdma_state_only() {
         let mut app = App::new();
         let t0 = Instant::now();
         app.apply_snapshot(snapshot(vec![port_stat("mlx5_0", 0)], t0));
         let mut bad = snapshot(Vec::new(), t0 + Duration::from_secs(2));
         bad.stats = None;
         app.apply_snapshot(bad);
-        // Skipped entirely: rows and baseline still intact.
+        // RDMA rows and baseline are held, not blanked.
         assert_eq!(app.throughputs.len(), 1);
         // Next good snapshot diffs against the ORIGINAL baseline: no spike.
         app.apply_snapshot(snapshot(
@@ -2316,5 +2380,19 @@ mod apply_snapshot_tests {
         ));
         // 1e9 bytes * 8 / 4 s / 1e9 = 2.0 Gbps
         assert!((app.throughputs[0].tx_gbps - 2.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn gpu_data_flows_when_rdma_read_always_fails() {
+        // A kernel without rdma netlink must still show NVLink data.
+        let mut app = App::new();
+        let t0 = Instant::now();
+        app.apply_snapshot(gpu_snapshot(0, t0));
+        assert!(app.has_data);
+        assert_eq!(app.throughputs.len(), 1);
+        assert_eq!(app.throughputs[0].tx_gbps, 0.0); // GPU baseline
+        app.apply_snapshot(gpu_snapshot(1_000_000_000, t0 + Duration::from_secs(2)));
+        // 1e9 bytes * 8 / 2 s / 1e9 = 4.0 Gbps
+        assert!((app.throughputs[0].tx_gbps - 4.0).abs() < 1e-9);
     }
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -356,7 +356,9 @@ pub struct App {
     pub cpu_history: Vec<f32>,
     prev_stats: Vec<PortStat>,
     prev_ifstats: Vec<IfStats>,
-    prev_time: Instant,
+    prev_taken_at: Option<Instant>,
+    pub has_data: bool,
+    pub sampler_dead: bool,
     pub rolling_avg: RollingAvgState,
     pub show_rolling_avg: bool,
     pub show_window_input: bool,
@@ -420,8 +422,6 @@ pub struct SysInfo {
 
 impl App {
     pub fn new() -> Self {
-        let stats = stat::read_all_stats().unwrap_or_default();
-        let ifstats = net::read_all_ifstats().unwrap_or_default();
         Self {
             should_quit: false,
             throughputs: Vec::new(),
@@ -435,9 +435,11 @@ impl App {
             sysinfo: read_sysinfo(NetRate::default()),
             history: HashMap::new(),
             cpu_history: Vec::with_capacity(HISTORY_LEN),
-            prev_stats: stats,
-            prev_ifstats: ifstats,
-            prev_time: Instant::now(),
+            prev_stats: Vec::new(),
+            prev_ifstats: Vec::new(),
+            prev_taken_at: None,
+            has_data: false,
+            sampler_dead: false,
             rolling_avg: RollingAvgState::new(ROLLING_AVG_DEFAULT_WINDOW),
             show_rolling_avg: false,
             show_window_input: false,
@@ -452,56 +454,77 @@ impl App {
             cached_display: Vec::new(),
             recorder: None,
             record_status: None,
-            // Pre-read like prev_stats: NVML/amdsmi counters are cumulative
-            // since driver load; an empty baseline causes a first-frame spike.
-            prev_nvlink: crate::nvlink::read_all_nvlink_stats().unwrap_or_default(),
-            prev_xgmi: crate::xgmi::read_all_xgmi_stats().unwrap_or_default(),
+            prev_nvlink: Vec::new(),
+            prev_xgmi: Vec::new(),
             active_tab: DeviceClass::Rdma,
             seen_tabs: vec![DeviceClass::Rdma],
             tab_selection: HashMap::new(),
         }
     }
 
-    pub fn refresh_stats(&mut self) {
-        let curr = match stat::read_all_stats() {
-            Ok(s) => s,
-            Err(_) => return,
-        };
-        let elapsed = self.prev_time.elapsed().as_secs_f64();
-        if elapsed < 0.1 {
+    /// Fold one sampler snapshot into the app state. The first snapshot is
+    /// the baseline: rows render immediately with zero rates (prev == curr),
+    /// real rates appear from the second snapshot on. Elapsed time comes
+    /// from sampler-side timestamps so UI queue latency can't skew rates.
+    pub fn apply_snapshot(&mut self, snap: crate::sampler::Snapshot) {
+        // A failed RDMA read poisons delta math (counters vs blank baseline);
+        // skip the whole snapshot, matching the old early-return.
+        let Some(stats) = snap.stats else {
             return;
-        }
-        self.throughputs = compute_throughputs(&self.prev_stats, &curr, elapsed);
-        self.prev_stats = curr;
+        };
+        let elapsed = match self.prev_taken_at {
+            Some(prev) => {
+                let e = snap.taken_at.duration_since(prev).as_secs_f64();
+                if e < 0.1 {
+                    return;
+                }
+                e
+            }
+            None => 1.0, // baseline: prev==curr below, so rates are zero
+        };
+        let baseline = self.prev_taken_at.is_none();
 
-        {
-            let curr_nvlink = crate::nvlink::read_all_nvlink_stats().unwrap_or_default();
-            let mut nvlink_rows =
-                compute_nvlink_throughputs(&self.prev_nvlink, &curr_nvlink, elapsed);
-            self.throughputs.append(&mut nvlink_rows);
-            self.prev_nvlink = curr_nvlink;
-        }
+        let prev_stats = if baseline { &stats } else { &self.prev_stats };
+        self.throughputs = compute_throughputs(prev_stats, &stats, elapsed);
 
-        {
-            let curr_xgmi = crate::xgmi::read_all_xgmi_stats().unwrap_or_default();
-            let mut xgmi_rows = compute_xgmi_throughputs(&self.prev_xgmi, &curr_xgmi, elapsed);
-            self.throughputs.append(&mut xgmi_rows);
-            self.prev_xgmi = curr_xgmi;
-        }
+        let prev_nvlink = if baseline {
+            &snap.nvlink
+        } else {
+            &self.prev_nvlink
+        };
+        let mut nvlink_rows = compute_nvlink_throughputs(prev_nvlink, &snap.nvlink, elapsed);
+        self.throughputs.append(&mut nvlink_rows);
+
+        let prev_xgmi = if baseline {
+            &snap.xgmi
+        } else {
+            &self.prev_xgmi
+        };
+        let mut xgmi_rows = compute_xgmi_throughputs(prev_xgmi, &snap.xgmi, elapsed);
+        self.throughputs.append(&mut xgmi_rows);
 
         // Stable display order: sort once here so history, rolling averages,
         // recording, and the display all inherit the same order.
         sort_by_device_order(&mut self.throughputs);
         detect_tabs(&mut self.seen_tabs, &self.throughputs);
 
-        let curr_if = net::read_all_ifstats().unwrap_or_default();
-        let net_rate = net::compute_net_rate(&self.prev_ifstats, &curr_if, elapsed);
-        self.prev_ifstats = curr_if;
+        let prev_if = if baseline {
+            &snap.ifstats
+        } else {
+            &self.prev_ifstats
+        };
+        let net_rate = net::compute_net_rate(prev_if, &snap.ifstats, elapsed);
 
-        self.prev_time = Instant::now();
+        self.prev_stats = stats;
+        self.prev_nvlink = snap.nvlink;
+        self.prev_xgmi = snap.xgmi;
+        self.prev_ifstats = snap.ifstats;
+        self.processes = snap.processes;
+        self.prev_taken_at = Some(snap.taken_at);
+        self.has_data = true;
+
         self.clamp_selection();
         self.update_history();
-        self.refresh_processes();
         self.rolling_avg.push(&self.throughputs);
         if let Some(rec) = &mut self.recorder {
             rec.push(port_metrics(&self.throughputs));
@@ -540,12 +563,6 @@ impl App {
                 .entry(t.dev_name.clone())
                 .or_insert_with(DeviceHistory::new)
                 .push(t.tx_gbps, t.rx_gbps);
-        }
-    }
-
-    fn refresh_processes(&mut self) {
-        if let Ok(qps) = stat::read_all_qps() {
-            self.processes = stat::aggregate_by_process(&qps);
         }
     }
 
@@ -2214,5 +2231,90 @@ mod tab_tests {
         app.active_tab = DeviceClass::Rdma;
         app.cycle_tab(true);
         assert_eq!(app.active_tab, DeviceClass::Rdma);
+    }
+}
+
+#[cfg(test)]
+mod apply_snapshot_tests {
+    use super::*;
+    use crate::sampler::Snapshot;
+    use crate::stat::{HwCounter, PortStat};
+
+    fn port_stat(dev: &str, tx_bytes: u64) -> PortStat {
+        PortStat {
+            dev_name: dev.to_string(),
+            port: 1,
+            link_gbps: Some(400.0),
+            counters: vec![HwCounter {
+                name: "tx_bytes".to_string(),
+                value: tx_bytes,
+            }],
+        }
+    }
+
+    fn snapshot(stats: Vec<PortStat>, taken_at: Instant) -> Snapshot {
+        Snapshot {
+            stats: Some(stats),
+            ifstats: Vec::new(),
+            nvlink: Vec::new(),
+            xgmi: Vec::new(),
+            processes: Vec::new(),
+            taken_at,
+        }
+    }
+
+    #[test]
+    fn first_snapshot_populates_rows_with_zero_rates() {
+        let mut app = App::new();
+        let t0 = Instant::now();
+        app.apply_snapshot(snapshot(vec![port_stat("mlx5_0", 1_000_000)], t0));
+        assert!(app.has_data);
+        assert_eq!(app.throughputs.len(), 1);
+        assert_eq!(app.throughputs[0].dev_name, "mlx5_0");
+        assert_eq!(app.throughputs[0].tx_gbps, 0.0); // baseline, no delta yet
+    }
+
+    #[test]
+    fn second_snapshot_computes_rates_from_thread_timestamps() {
+        let mut app = App::new();
+        let t0 = Instant::now();
+        app.apply_snapshot(snapshot(vec![port_stat("mlx5_0", 0)], t0));
+        // +1 GB over exactly 2s (thread timestamps, not wall clock here)
+        let t1 = t0 + Duration::from_secs(2);
+        app.apply_snapshot(snapshot(vec![port_stat("mlx5_0", 1_000_000_000)], t1));
+        // 1e9 bytes * 8 bits / 2 s / 1e9 = 4.0 Gbps
+        assert!((app.throughputs[0].tx_gbps - 4.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn subsecond_duplicate_snapshot_is_skipped() {
+        let mut app = App::new();
+        let t0 = Instant::now();
+        app.apply_snapshot(snapshot(vec![port_stat("mlx5_0", 0)], t0));
+        app.apply_snapshot(snapshot(
+            vec![port_stat("mlx5_0", 999)],
+            t0 + Duration::from_millis(50),
+        ));
+        // Skipped: rates still the baseline zeros.
+        assert_eq!(app.throughputs[0].tx_gbps, 0.0);
+    }
+
+    #[test]
+    fn failed_rdma_read_skips_snapshot() {
+        let mut app = App::new();
+        let t0 = Instant::now();
+        app.apply_snapshot(snapshot(vec![port_stat("mlx5_0", 0)], t0));
+        let mut bad = snapshot(Vec::new(), t0 + Duration::from_secs(2));
+        bad.stats = None;
+        app.apply_snapshot(bad);
+        // Skipped entirely: rows and baseline still intact.
+        assert_eq!(app.throughputs.len(), 1);
+        // Next good snapshot diffs against the ORIGINAL baseline: no spike.
+        app.apply_snapshot(snapshot(
+            vec![port_stat("mlx5_0", 1_000_000_000)],
+            t0 + Duration::from_secs(4),
+        ));
+        // 1e9 bytes * 8 / 4 s / 1e9 = 2.0 Gbps
+        assert!((app.throughputs[0].tx_gbps - 2.0).abs() < 1e-9);
     }
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -494,43 +494,45 @@ impl App {
                 return;
             }
         }
-        // Per-subsystem elapsed: measured to that subsystem's last success,
-        // so a skipped tick diffs cumulative counters over the true span.
-        let since = |at: Option<Instant>| at.map(|a| snap.taken_at.duration_since(a).as_secs_f64());
+        // Per-subsystem elapsed: each sample carries its own read-adjacent
+        // timestamp, measured to that subsystem's last success, so neither
+        // another subsystem's latency nor a skipped tick can skew the span.
+        let since =
+            |now: Instant, at: Option<Instant>| at.map(|a| now.duration_since(a).as_secs_f64());
 
-        if let Some(stats) = snap.stats {
-            self.rdma_rows = match since(self.prev_stats_at) {
-                Some(e) => compute_throughputs(&self.prev_stats, &stats, e),
-                None => compute_throughputs(&stats, &stats, 1.0), // baseline
+        if let Some(s) = snap.stats {
+            self.rdma_rows = match since(s.taken_at, self.prev_stats_at) {
+                Some(e) => compute_throughputs(&self.prev_stats, &s.data, e),
+                None => compute_throughputs(&s.data, &s.data, 1.0), // baseline
             };
-            self.prev_stats = stats;
-            self.prev_stats_at = Some(snap.taken_at);
+            self.prev_stats = s.data;
+            self.prev_stats_at = Some(s.taken_at);
         }
 
-        if let Some(nvlink) = snap.nvlink {
-            self.nvlink_rows = match since(self.prev_nvlink_at) {
-                Some(e) => compute_nvlink_throughputs(&self.prev_nvlink, &nvlink, e),
-                None => compute_nvlink_throughputs(&nvlink, &nvlink, 1.0), // baseline
+        if let Some(s) = snap.nvlink {
+            self.nvlink_rows = match since(s.taken_at, self.prev_nvlink_at) {
+                Some(e) => compute_nvlink_throughputs(&self.prev_nvlink, &s.data, e),
+                None => compute_nvlink_throughputs(&s.data, &s.data, 1.0), // baseline
             };
-            self.prev_nvlink = nvlink;
-            self.prev_nvlink_at = Some(snap.taken_at);
+            self.prev_nvlink = s.data;
+            self.prev_nvlink_at = Some(s.taken_at);
         }
 
-        if let Some(xgmi) = snap.xgmi {
-            self.xgmi_rows = match since(self.prev_xgmi_at) {
-                Some(e) => compute_xgmi_throughputs(&self.prev_xgmi, &xgmi, e),
-                None => compute_xgmi_throughputs(&xgmi, &xgmi, 1.0), // baseline
+        if let Some(s) = snap.xgmi {
+            self.xgmi_rows = match since(s.taken_at, self.prev_xgmi_at) {
+                Some(e) => compute_xgmi_throughputs(&self.prev_xgmi, &s.data, e),
+                None => compute_xgmi_throughputs(&s.data, &s.data, 1.0), // baseline
             };
-            self.prev_xgmi = xgmi;
-            self.prev_xgmi_at = Some(snap.taken_at);
+            self.prev_xgmi = s.data;
+            self.prev_xgmi_at = Some(s.taken_at);
         }
 
-        if let Some(ifstats) = snap.ifstats {
-            if let Some(e) = since(self.prev_ifstats_at) {
-                self.net_rate = net::compute_net_rate(&self.prev_ifstats, &ifstats, e);
+        if let Some(s) = snap.ifstats {
+            if let Some(e) = since(s.taken_at, self.prev_ifstats_at) {
+                self.net_rate = net::compute_net_rate(&self.prev_ifstats, &s.data, e);
             }
-            self.prev_ifstats = ifstats;
-            self.prev_ifstats_at = Some(snap.taken_at);
+            self.prev_ifstats = s.data;
+            self.prev_ifstats_at = Some(s.taken_at);
         }
 
         if let Some(processes) = snap.processes {
@@ -2288,12 +2290,16 @@ mod apply_snapshot_tests {
         }
     }
 
+    fn sample<T>(data: T, taken_at: Instant) -> Option<crate::sampler::Sample<T>> {
+        Some(crate::sampler::Sample { data, taken_at })
+    }
+
     fn snapshot(stats: Vec<PortStat>, taken_at: Instant) -> Snapshot {
         Snapshot {
-            stats: Some(stats),
-            ifstats: Some(Vec::new()),
-            nvlink: Some(Vec::new()),
-            xgmi: Some(Vec::new()),
+            stats: sample(stats, taken_at),
+            ifstats: sample(Vec::new(), taken_at),
+            nvlink: sample(Vec::new(), taken_at),
+            xgmi: sample(Vec::new(), taken_at),
             processes: Some(Vec::new()),
             taken_at,
         }
@@ -2311,12 +2317,28 @@ mod apply_snapshot_tests {
         };
         Snapshot {
             stats: None, // e.g. kernel without rdma netlink support
-            ifstats: Some(Vec::new()),
-            nvlink: Some(vec![gpu]),
-            xgmi: Some(Vec::new()),
+            ifstats: sample(Vec::new(), taken_at),
+            nvlink: sample(vec![gpu], taken_at),
+            xgmi: sample(Vec::new(), taken_at),
             processes: Some(Vec::new()),
             taken_at,
         }
+    }
+
+    #[test]
+    fn rates_use_per_subsystem_read_timestamps() {
+        // A slow pass must not skew a subsystem read later in it: the GPU
+        // sample's own timestamp, not the pass start, drives its elapsed.
+        let mut app = App::new();
+        let t0 = Instant::now();
+        let mut first = gpu_snapshot(0, t0);
+        // First pass was slow: GPU counters actually read 2s after pass start.
+        first.nvlink.as_mut().unwrap().taken_at = t0 + Duration::from_secs(2);
+        app.apply_snapshot(first);
+        // Second pass, fast: read at t0+4s -> true GPU window is 2s, not 4s.
+        app.apply_snapshot(gpu_snapshot(1_000_000_000, t0 + Duration::from_secs(4)));
+        // 1e9 bytes * 8 / 2 s / 1e9 = 4.0 Gbps (2.0 would mean pass-start skew)
+        assert!((app.throughputs[0].tx_gbps - 4.0).abs() < 1e-9);
     }
 
     #[test]

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -391,6 +391,21 @@ fn draw_gpu_table(frame: &mut Frame, app: &mut App, area: Rect, tc: &ThemeColors
         format!(" {} Throughput ", label)
     };
 
+    // Before the first background-sampler snapshot arrives, show a placeholder.
+    if display.is_empty() && !app.has_data {
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_set(super::glyphs::border())
+            .border_style(Style::default().fg(tc.border))
+            .title(title)
+            .title_style(Style::default().fg(tc.accent));
+        let msg = Paragraph::new("initializing devices...")
+            .style(Style::default().fg(tc.muted))
+            .block(block);
+        frame.render_widget(msg, area);
+        return;
+    }
+
     let header = Row::new(vec![
         "Device", "Name", "Links", "Speed", "TX", "Gbps", "RX", "Gbps", "Errs",
     ])
@@ -479,6 +494,21 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect, tc: &ThemeColors) {
     } else {
         " RDMA Throughput ".to_string()
     };
+
+    // Before the first background-sampler snapshot arrives, show a placeholder.
+    if display.is_empty() && !app.has_data {
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_set(super::glyphs::border())
+            .border_style(Style::default().fg(tc.border))
+            .title(title)
+            .title_style(Style::default().fg(tc.accent));
+        let msg = Paragraph::new("initializing devices...")
+            .style(Style::default().fg(tc.muted))
+            .block(block);
+        frame.render_widget(msg, area);
+        return;
+    }
 
     // In detail mode, use default columns with no scrolling (original behavior).
     // In normal mode, use configured columns with horizontal scroll.
@@ -1147,6 +1177,12 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeColors) {
         spans.push(Span::styled(
             format!(" {} ", msg),
             Style::default().fg(tc.fg),
+        ));
+    }
+    if app.sampler_dead {
+        spans.push(Span::styled(
+            " sampler stopped - data frozen ",
+            Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
         ));
     }
     spans.push(keys);

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -377,6 +377,32 @@ fn gpu_row_cells(t: &PortThroughput, tc: &ThemeColors) -> Vec<Cell<'static>> {
     ]
 }
 
+/// Bordered placeholder shown in a table area before the first snapshot:
+/// "initializing" while the sampler is warming up, "failed" once it died.
+fn draw_startup_placeholder(
+    frame: &mut Frame,
+    app: &App,
+    area: Rect,
+    tc: &ThemeColors,
+    title: String,
+) {
+    let text = if app.sampler_error.is_some() {
+        "sampling failed - see status bar"
+    } else {
+        "initializing devices..."
+    };
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_set(super::glyphs::border())
+        .border_style(Style::default().fg(tc.border))
+        .title(title)
+        .title_style(Style::default().fg(tc.accent));
+    let msg = Paragraph::new(text)
+        .style(Style::default().fg(tc.muted))
+        .block(block);
+    frame.render_widget(msg, area);
+}
+
 /// GPU-tab table: fixed columns for XGMI / NVLink rows.
 /// h-scroll and the column picker are RDMA-only; this function ignores both.
 fn draw_gpu_table(frame: &mut Frame, app: &mut App, area: Rect, tc: &ThemeColors) {
@@ -393,16 +419,7 @@ fn draw_gpu_table(frame: &mut Frame, app: &mut App, area: Rect, tc: &ThemeColors
 
     // Before the first background-sampler snapshot arrives, show a placeholder.
     if display.is_empty() && !app.has_data {
-        let block = Block::default()
-            .borders(Borders::ALL)
-            .border_set(super::glyphs::border())
-            .border_style(Style::default().fg(tc.border))
-            .title(title)
-            .title_style(Style::default().fg(tc.accent));
-        let msg = Paragraph::new("initializing devices...")
-            .style(Style::default().fg(tc.muted))
-            .block(block);
-        frame.render_widget(msg, area);
+        draw_startup_placeholder(frame, app, area, tc, title);
         return;
     }
 
@@ -497,16 +514,7 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect, tc: &ThemeColors) {
 
     // Before the first background-sampler snapshot arrives, show a placeholder.
     if display.is_empty() && !app.has_data {
-        let block = Block::default()
-            .borders(Borders::ALL)
-            .border_set(super::glyphs::border())
-            .border_style(Style::default().fg(tc.border))
-            .title(title)
-            .title_style(Style::default().fg(tc.accent));
-        let msg = Paragraph::new("initializing devices...")
-            .style(Style::default().fg(tc.muted))
-            .block(block);
-        frame.render_widget(msg, area);
+        draw_startup_placeholder(frame, app, area, tc, title);
         return;
     }
 
@@ -1179,9 +1187,15 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeColors) {
             Style::default().fg(tc.fg),
         ));
     }
-    if app.sampler_dead {
+    if let Some(err) = &app.sampler_error {
         spans.push(Span::styled(
-            " sampler stopped - data frozen ",
+            super::glyphs::tr(&format!(" sampler died: {} ", err)).into_owned(),
+            Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+        ));
+    } else if let Some(secs) = app.stale_secs() {
+        // A wedged (not dead) sampler: data is old but still rendered.
+        spans.push(Span::styled(
+            format!(" STALE {}s - sampler stalled ", secs),
             Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
         ));
     }

--- a/src/xgmi.rs
+++ b/src/xgmi.rs
@@ -252,10 +252,13 @@ pub fn read_all_xgmi_stats() -> io::Result<Vec<XgmiSnapshot>> {
     let bdfs: Vec<Option<u64>> = handles.iter().map(|&h| read_bdf(api, h)).collect();
     let names = gpu_names(api, &handles);
     let speeds = link_speeds(api, &handles);
+    let peers = xgmi_peers(api, &handles);
 
     let mut snapshots = Vec::with_capacity(handles.len());
     for idx in 0..handles.len() {
-        if let Some(snap) = read_processor_snapshot(api, &handles, &bdfs, names, &speeds, idx) {
+        if let Some(snap) =
+            read_processor_snapshot(api, &handles, &bdfs, names, &speeds, peers, idx)
+        {
             snapshots.push(snap);
         }
     }
@@ -271,6 +274,21 @@ fn gpu_names(api: &Amdsmi, handles: &[ffi::ProcessorHandle]) -> &'static [String
         handles
             .iter()
             .map(|&h| read_gpu_name(api, h).unwrap_or_default())
+            .collect()
+    })
+}
+
+/// XGMI peer adjacency, row-major [src][dst]. Topology cannot change while
+/// the driver is loaded, so the O(N^2) topo_get_link_type sweep runs once.
+fn xgmi_peers(api: &Amdsmi, handles: &[ffi::ProcessorHandle]) -> &'static [Vec<bool>] {
+    static PEERS: OnceLock<Vec<Vec<bool>>> = OnceLock::new();
+    PEERS.get_or_init(|| {
+        (0..handles.len())
+            .map(|src| {
+                (0..handles.len())
+                    .map(|dst| src != dst && is_xgmi_peer(api, handles[src], handles[dst]))
+                    .collect()
+            })
             .collect()
     })
 }
@@ -350,6 +368,7 @@ fn read_processor_snapshot(
     bdfs: &[Option<u64>],
     names: &[String],
     speeds: &[LinkSpeed],
+    peers: &[Vec<bool>],
     idx: usize,
 ) -> Option<XgmiSnapshot> {
     let handle = handles[idx];
@@ -367,8 +386,14 @@ fn read_processor_snapshot(
     let n = (metrics.num_links as usize).min(ffi::AMDSMI_MAX_NUM_XGMI_PHYSICAL_LINK);
     let mut links = Vec::new();
     let mut total_gbps = 0.0;
-    for (peer_idx, &peer) in handles.iter().enumerate() {
-        if peer_idx == idx || !is_xgmi_peer(api, handle, peer) {
+    for (peer_idx, peer_bdf) in bdfs.iter().enumerate() {
+        if peer_idx == idx
+            || !peers
+                .get(idx)
+                .and_then(|row| row.get(peer_idx))
+                .copied()
+                .unwrap_or(false)
+        {
             continue;
         }
         // Accumulators are indexed by destination GPU; peers beyond the
@@ -376,14 +401,10 @@ fn read_processor_snapshot(
         // The positional mapping is trusted only while the entry's own bdf
         // is unset (always zero on ROCm 6.4) or agrees with the peer's.
         let (tx_bytes, rx_bytes) = match metrics.links.get(peer_idx) {
-            Some(entry)
-                if peer_idx < n && (entry.bdf == 0 || Some(entry.bdf) == bdfs[peer_idx]) =>
-            {
-                (
-                    Some(entry.write_kb.wrapping_mul(1024)),
-                    Some(entry.read_kb.wrapping_mul(1024)),
-                )
-            }
+            Some(entry) if peer_idx < n && (entry.bdf == 0 || Some(entry.bdf) == *peer_bdf) => (
+                Some(entry.write_kb.wrapping_mul(1024)),
+                Some(entry.read_kb.wrapping_mul(1024)),
+            ),
             _ => (None, None),
         };
         total_gbps += speed_gbps.unwrap_or(0.0);
@@ -394,7 +415,7 @@ fn read_processor_snapshot(
             is_active: true,
             speed_gbps,
             bit_rate_gbps,
-            remote_pci_bdf: bdfs[peer_idx].map(format_bdf),
+            remote_pci_bdf: peer_bdf.map(format_bdf),
             tx_bytes,
             rx_bytes,
         });

--- a/src/xgmi.rs
+++ b/src/xgmi.rs
@@ -257,7 +257,7 @@ pub fn read_all_xgmi_stats() -> io::Result<Vec<XgmiSnapshot>> {
     let mut snapshots = Vec::with_capacity(handles.len());
     for idx in 0..handles.len() {
         if let Some(snap) =
-            read_processor_snapshot(api, &handles, &bdfs, names, &speeds, peers, idx)
+            read_processor_snapshot(api, &handles, &bdfs, names, &speeds, &peers, idx)
         {
             snapshots.push(snap);
         }
@@ -278,19 +278,35 @@ fn gpu_names(api: &Amdsmi, handles: &[ffi::ProcessorHandle]) -> &'static [String
     })
 }
 
-/// XGMI peer adjacency, row-major [src][dst]. Topology cannot change while
-/// the driver is loaded, so the O(N^2) topo_get_link_type sweep runs once.
-fn xgmi_peers(api: &Amdsmi, handles: &[ffi::ProcessorHandle]) -> &'static [Vec<bool>] {
-    static PEERS: OnceLock<Vec<Vec<bool>>> = OnceLock::new();
-    PEERS.get_or_init(|| {
-        (0..handles.len())
-            .map(|src| {
-                (0..handles.len())
-                    .map(|dst| src != dst && is_xgmi_peer(api, handles[src], handles[dst]))
-                    .collect()
-            })
-            .collect()
-    })
+/// XGMI peer adjacency, row-major [src][dst]. Topology is static while the
+/// driver is loaded, so the O(N^2) topo sweep is cached — but only once every
+/// call answered and only while the GPU count matches (retry/rebuild otherwise).
+fn xgmi_peers(api: &Amdsmi, handles: &[ffi::ProcessorHandle]) -> Vec<Vec<bool>> {
+    static PEERS: Mutex<Option<Vec<Vec<bool>>>> = Mutex::new(None);
+    let mut cached = PEERS.lock().unwrap_or_else(|e| e.into_inner());
+    if let Some(m) = cached.as_ref() {
+        if m.len() == handles.len() {
+            return m.clone();
+        }
+    }
+    let n = handles.len();
+    let mut matrix = vec![vec![false; n]; n];
+    let mut complete = true;
+    for src in 0..n {
+        for dst in 0..n {
+            if src == dst {
+                continue;
+            }
+            match is_xgmi_peer(api, handles[src], handles[dst]) {
+                Some(peer) => matrix[src][dst] = peer,
+                None => complete = false,
+            }
+        }
+    }
+    if complete && n > 0 {
+        *cached = Some(matrix.clone());
+    }
+    matrix
 }
 
 /// Per-link (bit_rate, bandwidth) in Gb/s from PCIe static info.
@@ -437,12 +453,21 @@ fn read_processor_snapshot(
     })
 }
 
-/// True when topology reports an XGMI io-link between the two GPUs.
-fn is_xgmi_peer(api: &Amdsmi, src: ffi::ProcessorHandle, dst: ffi::ProcessorHandle) -> bool {
+/// Whether topology reports an XGMI io-link between the two GPUs.
+/// `None` when the topo query itself failed (transient during GPU init),
+/// so callers can retry instead of caching a false negative.
+fn is_xgmi_peer(
+    api: &Amdsmi,
+    src: ffi::ProcessorHandle,
+    dst: ffi::ProcessorHandle,
+) -> Option<bool> {
     let mut hops: u64 = 0;
     let mut link_type: u32 = 0;
     let rc = unsafe { (api.topo_get_link_type)(src, dst, &mut hops, &mut link_type) };
-    rc == ffi::AMDSMI_STATUS_SUCCESS && link_type == ffi::AMDSMI_IOLINK_TYPE_XGMI
+    if rc != ffi::AMDSMI_STATUS_SUCCESS {
+        return None;
+    }
+    Some(link_type == ffi::AMDSMI_IOLINK_TYPE_XGMI)
 }
 
 /// Per-link (bit_rate, bandwidth) in Gb/s from PCIe static info, mirroring


### PR DESCRIPTION
## Purpose

Cold start blocked on two full sampling passes plus NVML/amdsmi driver init before the first frame, `Nvml::init()/nvmlShutdown` ran every tick, and any slow driver call froze rendering and input.

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes
- [x] Tested on RDMA-capable hardware (or explained why not in the Test Plan)
- [ ] Docs/README updated if behavior or flags changed
