### PR TITLE
fix: bound netlink recv with SO_RCVTIMEO to prevent sampler wedge

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ rdmatop
 
 Press `r` in the TUI to start recording and `r` again to stop. rdmatop captures
 every device's tx/rx Gbps and packets/s per interval and writes a Chrome-JSON
-trace (`rdmatop-<n>.json`) you can drag into [ui.perfetto.dev](https://ui.perfetto.dev)
+trace (`rdmatop-<unix_timestamp>.json`, in the current directory) you can drag into [ui.perfetto.dev](https://ui.perfetto.dev)
 — each device/port becomes its own set of counter tracks. Timestamps are relative
 to when you pressed `r`, so the trace spans exactly your record window.
 

--- a/src/netlink.rs
+++ b/src/netlink.rs
@@ -8,6 +8,12 @@ const NLMSG_HDR_LEN: usize = 16;
 const NLA_HDR_LEN: usize = 4;
 const NLA_ALIGN: usize = 4;
 
+/// Receive timeout for every netlink socket (seconds). A kernel that never
+/// terminates a dump must not wedge the sampler thread forever; recv() then
+/// fails with WouldBlock/TimedOut and the subsystem degrades like any other
+/// read error.
+const RECV_TIMEOUT_SECS: libc::time_t = 2;
+
 fn align(len: usize) -> usize {
     (len + NLA_ALIGN - 1) & !(NLA_ALIGN - 1)
 }
@@ -189,6 +195,28 @@ impl NlSocket {
             unsafe { libc::close(fd) };
             return Err(io::Error::last_os_error());
         }
+        // Bound every recv: a kernel that never terminates a dump (no
+        // NLMSG_DONE/NLMSG_ERROR) must not wedge the sampler thread
+        // forever. Timeouts surface as WouldBlock/TimedOut io::Errors,
+        // which the existing per-subsystem error handling already
+        // degrades gracefully.
+        let tv = libc::timeval {
+            tv_sec: RECV_TIMEOUT_SECS,
+            tv_usec: 0,
+        };
+        let ret = unsafe {
+            libc::setsockopt(
+                fd,
+                libc::SOL_SOCKET,
+                libc::SO_RCVTIMEO,
+                &tv as *const _ as *const libc::c_void,
+                std::mem::size_of_val(&tv) as libc::socklen_t,
+            )
+        };
+        if ret < 0 {
+            unsafe { libc::close(fd) };
+            return Err(io::Error::last_os_error());
+        }
         Ok(Self { fd })
     }
 
@@ -260,5 +288,31 @@ pub fn collect_responses<T>(
 impl Drop for NlSocket {
     fn drop(&mut self) {
         unsafe { libc::close(self.fd) };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression: every socket must carry a receive timeout, or a kernel
+    /// that never terminates a dump wedges the sampler thread forever with
+    /// no panic and no surfaced error.
+    #[test]
+    fn open_sets_receive_timeout() {
+        let sock = NlSocket::open(NETLINK_RDMA).expect("open rdma netlink socket");
+        let mut tv: libc::timeval = unsafe { mem::zeroed() };
+        let mut len = std::mem::size_of_val(&tv) as libc::socklen_t;
+        let ret = unsafe {
+            libc::getsockopt(
+                sock.fd,
+                libc::SOL_SOCKET,
+                libc::SO_RCVTIMEO,
+                &mut tv as *mut _ as *mut libc::c_void,
+                &mut len,
+            )
+        };
+        assert_eq!(ret, 0, "getsockopt SO_RCVTIMEO failed");
+        assert_eq!(tv.tv_sec, RECV_TIMEOUT_SECS, "receive timeout not applied");
     }
 }


### PR DESCRIPTION
fix: bound netlink recv with SO_RCVTIMEO to prevent sampler wedge

## Problem
`NlSocket::open` never sets a receive timeout, and `request()` loops on `recv()` until NLMSG_DONE/NLMSG_ERROR arrives. Missing NLMSG_DONE has wedged real deployments — SONiC swss-common#114 ("due to the missing of NLMSG_DONE flag in netlink message, the netlink process got stuck"), Chromium 41392921 (the kernel can drop netlink messages under memory pressure, so a loop-until-DONE can block forever). If that happens here, the sampler thread blocks with no panic and no surfaced error — the TUI silently freezes on stale data. That's the hang-variant of the project's own ground rule ("Never crash the TUI over missing hardware").

## Fix
After bind, set `SO_RCVTIMEO` (2s). A timed-out `recv()` fails with EAGAIN (WouldBlock), which the existing per-subsystem error handling already degrades gracefully — no new plumbing.

## Test plan
- New regression test `open_sets_receive_timeout()` asserts every socket carries the receive timeout (`getsockopt`). It pins the setsockopt itself (presence of the timeout), not the wedge behavior — the happy path is covered by the existing suite plus the live run below.
- `cargo test`: 71 passed, 0 failed (1 ignored hardware smoke test).
- `cargo fmt --check` and `cargo clippy --release -- -D warnings` clean.
- Live: drove the TUI on a host with zero RDMA devices (amd64, Linux 6.x); enumeration and sampling unchanged, clean quit (exit 0). No RDMA hardware access, so the timeout path is unit-proven; the happy path is live-proven.

Reported by a two-corner audit (Oracle + Windy).



Companion triage issue: https://github.com/uccl-project/rdmatop/issues/44
